### PR TITLE
[WIP] Add support of ng-pattern for text and textarea fields

### DIFF
--- a/src/directives/formly-field-text.html
+++ b/src/directives/formly-field-text.html
@@ -9,5 +9,6 @@
 		   placeholder="{{options.placeholder}}"
 		   ng-required="options.required"
 		   ng-disabled="options.disabled"
-		   ng-model="value">
+		   ng-model="value"
+           ng-pattern="{{ options.pattern }}">
 </div>

--- a/src/directives/formly-field-textarea.html
+++ b/src/directives/formly-field-textarea.html
@@ -10,6 +10,8 @@
 			  placeholder="{{options.placeholder}}"
 			  ng-required="options.required"
 			  ng-disabled="options.disabled"
-			  ng-model="value">
+			  ng-model="value"
+              ng-pattern="{{ options.pattern }}"
+            >
 	</textarea>
 </div>


### PR DESCRIPTION
This add support of ng-pattern

``` json
 {
        "key": "firstName",
        "type": "text",
        "label": "First Name",
        "placeholder": "Jane",
        "pattern": "/^[a-zA-Z0-9]*$/"
    },
    {
        "key": "about",
        "type": "textarea",
        "label": "Tell me about yourself",
        "placeholder": "I like puppies",
        "pattern": "/^[a-zA-Z0-9]*$/",
        "lines": 4
    }
}
```

i will update the README, if it is ok.
