### PR TITLE
Fixes #55 (probably).

### DIFF
--- a/src/directives/formly-form.js
+++ b/src/directives/formly-form.js
@@ -27,7 +27,9 @@ angular.module('formly.render')
 		controller: function($scope, $element, $parse) {
 			// setup watches for watchExpressions
 			angular.forEach($scope.fields, function(field, index) {
-				if (angular.isDefined(field.watch)) {
+				if (angular.isDefined(field.watch) &&
+					angular.isDefined(field.watch.expression) &&
+					angular.isDefined(field.watch.listener)) {
 					var watchExpression = field.watch.expression;
 					if (angular.isFunction(watchExpression)) {
 						// wrap the field's watch expression so we can call it with the field as the first arg as a helper


### PR DESCRIPTION
Still not certain how the demo would have gotten into a state to reveal this bug, and I was not able to reproduce this, but with this change, a watch will not get created unless there is both an expression and a listener.
