### PR TITLE
Closes #60. select: save option.value to model and not entire option

### DIFF
--- a/src/directives/formly-field-select.html
+++ b/src/directives/formly-field-select.html
@@ -9,7 +9,7 @@
 			ng-required="options.required"
 			ng-disabled="options.disabled"
 			ng-init="value = options.options[options.default]"
-			ng-options="option.name group by option.group for option in options.options">
+			ng-options="option.value as option.name group by option.group for option in options.options">
 	</select>
   <p id="{{id}}_description" ng-if="options.description">{{options.description}}</p>
 </div>


### PR DESCRIPTION
The way data is stored in the result object is different for select and radio. I think it is a bug. If it was designed on purpose, could you explain why?

Here is the plunker: http://plnkr.co/edit/dUiO4aWXQoZlyuE6L5iy

selecting a item using the select will store the complete object in the result
result.triedEmberSelect: {
"name": "Yes, and I love it!",
"value": "yesyes"
}

selecting an item using the radio will store only the value:
result.triedEmberRadio: "yesyes"

Thanks in advance, great module!
