### PR TITLE
actually retrieve template data

### DIFF
--- a/src/common/directives/formly-field.js
+++ b/src/common/directives/formly-field.js
@@ -14,7 +14,7 @@ angular.module('formly.render')
 		link: function fieldLink($scope, $element, $attr) {
 			var template = $scope.options.template || formlyConfig.getTemplate($scope.options.type);
 			if (template) {
-				setElementTemplate(template);
+				setElementTemplate($templateCache.get(template));
 			} else {
 				var templateUrl = $scope.options.templateUrl || formlyConfig.getTemplateUrl($scope.options.type);
 				if (templateUrl) {


### PR DESCRIPTION
The template needs to be retrieved from the $templateCache. If not done, one gets the templateUrl instead of the HTML form.
