### PR TITLE
Partially revert 0225a1

### DIFF
--- a/src/common/directives/formly-form.js
+++ b/src/common/directives/formly-form.js
@@ -55,21 +55,20 @@ angular.module('formly.render')
 					}
 				});
 			}, true);
-
-			if ($scope.formOnParentScope) {
-				$scope.$on('formly-dynamic-name-update', function(e) {
-					e.stopPropagation();
-					window.setTimeout(function() {
-						angular.forEach($scope.fields, function(field) {
-							var formField = $scope.formOnParentScope[field.key];
-							if (formField) {
-								field.formField = formField;
-							}
-						});
-					}); // next tick, give angular an event loop to finish compiling
-				});
-			}
-
+			$scope.$on('formly-dynamic-name-update', function(e) {
+				e.stopPropagation();
+				if (!$scope.formOnParentScope) {
+					return;
+				}
+				window.setTimeout(function() {
+					angular.forEach($scope.fields, function(field) {
+						var formField = $scope.formOnParentScope[field.key];
+						if (formField) {
+							field.formField = formField;
+						}
+					});
+				}); // next tick, give angular an event loop to finish compiling
+			});
 		}
 	};
 });


### PR DESCRIPTION
Commit 0225a1 prevented accessing a possibly null/undefined dictionary inside
the scope, but the way it was handling it was preventing formly-dynamic-name-update
listener from been registered.

The proposed solution keeps checking for if $scope.formOnParentScope is defined,
but inside the event handler, making it aware of scope changes
