### PR TITLE
fix typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ formlyConfig.setType([
   },
   {
     name: 'button',
-    templateUrl: '<button ng-click="options.templateOptions">{{options.label</button>'
+    templateUrl: '<button ng-click="options.templateOptions">{{options.label}}</button>'
   }
 ]);
 


### PR DESCRIPTION
Adds the missing closing braces `}}` in the README example.