### PR TITLE
REVIEW:  switch all modules over to es6 modules instead of angular modules

### DIFF
--- a/src/directives/formly-custom-validation.js
+++ b/src/directives/formly-custom-validation.js
@@ -1,4 +1,4 @@
-function formlyCustomValidation(formlyUtil, $q) {
+export default function formlyCustomValidation(formlyUtil, $q) {
   return {
     restrict: 'A',
     require: 'ngModel',
@@ -105,5 +105,3 @@ function formlyCustomValidation(formlyUtil, $q) {
     }
   }
 }
-
-export default formlyCustomValidation;

--- a/src/directives/formly-custom-validation.js
+++ b/src/directives/formly-custom-validation.js
@@ -1,113 +1,109 @@
-module.exports = ngModule => {
-  ngModule.directive('formlyCustomValidation', formlyCustomValidation);
+function formlyCustomValidation(formlyUtil, $q) {
+  return {
+    restrict: 'A',
+    require: 'ngModel',
+    link: function(scope, el, attrs, ctrl) {
+      const opts = scope.options;
+      if (opts.validators) {
+        checkValidators(opts.validators);
+      }
+      opts.validation.messages = opts.validation.messages || {};
+      angular.forEach(opts.validation.messages, (message, key) => {
+        opts.validation.messages[key] = () => {
+          return formlyUtil.formlyEval(scope, message, ctrl.$modelValue, ctrl.$viewValue);
+        };
+      });
 
-  formlyCustomValidation.tests = ON_TEST ? require('./formly-custom-validation.test')(ngModule) : null;
 
-  function formlyCustomValidation(formlyUtil, $q) {
-    return {
-      restrict: 'A',
-      require: 'ngModel',
-      link: function(scope, el, attrs, ctrl) {
-        const opts = scope.options;
-        if (opts.validators) {
-          checkValidators(opts.validators);
-        }
-        opts.validation.messages = opts.validation.messages || {};
-        angular.forEach(opts.validation.messages, (message, key) => {
-          opts.validation.messages[key] = () => {
+      var useNewValidatorsApi = ctrl.hasOwnProperty('$validators') && !attrs.hasOwnProperty('useParsers');
+      angular.forEach(opts.validators, function(validator, name) {
+        var message = validator.message;
+        if (message) {
+          opts.validation.messages[name] = () => {
             return formlyUtil.formlyEval(scope, message, ctrl.$modelValue, ctrl.$viewValue);
           };
-        });
-
-
-        var useNewValidatorsApi = ctrl.hasOwnProperty('$validators') && !attrs.hasOwnProperty('useParsers');
-        angular.forEach(opts.validators, function(validator, name) {
-          var message = validator.message;
-          if (message) {
-            opts.validation.messages[name] = () => {
-              return formlyUtil.formlyEval(scope, message, ctrl.$modelValue, ctrl.$viewValue);
-            };
-          }
-          validator = angular.isObject(validator) ? validator.expression : validator;
-          var isPossiblyAsync = !angular.isString(validator);
-          if (useNewValidatorsApi) {
-            setupWithValidators();
-          } else {
-            setupWithParsers();
-          }
-
-          function setupWithValidators() {
-            var validatorCollection = isPossiblyAsync ? '$asyncValidators' : '$validators';
-            ctrl[validatorCollection][name] = function(modelValue, viewValue) {
-              var value = formlyUtil.formlyEval(scope, validator, modelValue, viewValue);
-              if (isPossiblyAsync) {
-                return isPromiseLike(value) ? value : value ? $q.when(value) : $q.reject(value);
-              } else {
-                return value;
-              }
-            };
-          }
-
-          function setupWithParsers() {
-            let inFlightValidator;
-            ctrl.$parsers.unshift(function(viewValue) {
-              var isValid = formlyUtil.formlyEval(scope, validator, ctrl.$modelValue, viewValue);
-              if (isPromiseLike(isValid)) {
-                ctrl.$pending = ctrl.$pending || {};
-                ctrl.$pending[name] = true;
-                inFlightValidator = isValid;
-                isValid.then(() => {
-                  if (inFlightValidator === isValid) {
-                    ctrl.$setValidity(name, true);
-                  }
-                }).catch(() => {
-                  if (inFlightValidator === isValid) {
-                    ctrl.$setValidity(name, false);
-                  }
-                }).finally(() => {
-                  if (Object.keys(ctrl.$pending).length === 1) {
-                    delete ctrl.$pending;
-                  } else {
-                    delete ctrl.$pending[name];
-                  }
-                });
-              } else {
-                ctrl.$setValidity(name, isValid);
-              }
-              return viewValue;
-            });
-          }
-        });
-      }
-    };
-
-    function isPromiseLike(obj) {
-      return obj && angular.isFunction(obj.then);
-    }
-
-    function checkValidators(validators) {
-      var allowedProperties = ['expression', 'message'];
-      var validatorsWithExtraProps = {};
-      angular.forEach(validators, (validator, name) => {
-        if (angular.isString(validator)) {
-          return;
         }
-        var extraProps = [];
-        angular.forEach(validator, (v, key) => {
-          if (allowedProperties.indexOf(key) === -1) {
-            extraProps.push(key);
-          }
-        });
-        if (extraProps.length) {
-          validatorsWithExtraProps[name] = extraProps;
+        validator = angular.isObject(validator) ? validator.expression : validator;
+        var isPossiblyAsync = !angular.isString(validator);
+        if (useNewValidatorsApi) {
+          setupWithValidators();
+        } else {
+          setupWithParsers();
+        }
+
+        function setupWithValidators() {
+          var validatorCollection = isPossiblyAsync ? '$asyncValidators' : '$validators';
+          ctrl[validatorCollection][name] = function(modelValue, viewValue) {
+            var value = formlyUtil.formlyEval(scope, validator, modelValue, viewValue);
+            if (isPossiblyAsync) {
+              return isPromiseLike(value) ? value : value ? $q.when(value) : $q.reject(value);
+            } else {
+              return value;
+            }
+          };
+        }
+
+        function setupWithParsers() {
+          let inFlightValidator;
+          ctrl.$parsers.unshift(function(viewValue) {
+            var isValid = formlyUtil.formlyEval(scope, validator, ctrl.$modelValue, viewValue);
+            if (isPromiseLike(isValid)) {
+              ctrl.$pending = ctrl.$pending || {};
+              ctrl.$pending[name] = true;
+              inFlightValidator = isValid;
+              isValid.then(() => {
+                if (inFlightValidator === isValid) {
+                  ctrl.$setValidity(name, true);
+                }
+              }).catch(() => {
+                if (inFlightValidator === isValid) {
+                  ctrl.$setValidity(name, false);
+                }
+              }).finally(() => {
+                if (Object.keys(ctrl.$pending).length === 1) {
+                  delete ctrl.$pending;
+                } else {
+                  delete ctrl.$pending[name];
+                }
+              });
+            } else {
+              ctrl.$setValidity(name, isValid);
+            }
+            return viewValue;
+          });
         }
       });
-      if (Object.keys(validatorsWithExtraProps).length) {
-        throw new Error([
-          `Validators are only allowed to be functions or objects that have ${allowedProperties.join(', ')}.`,
-          `You provided some extra properties: ${JSON.stringify(validatorsWithExtraProps)}`
-        ].join(' '));
+    }
+  };
+
+  function isPromiseLike(obj) {
+    return obj && angular.isFunction(obj.then);
+  }
+
+  function checkValidators(validators) {
+    var allowedProperties = ['expression', 'message'];
+    var validatorsWithExtraProps = {};
+    angular.forEach(validators, (validator, name) => {
+      if (angular.isString(validator)) {
+        return;
       }
+      var extraProps = [];
+      angular.forEach(validator, (v, key) => {
+        if (allowedProperties.indexOf(key) === -1) {
+          extraProps.push(key);
+        }
+      });
+      if (extraProps.length) {
+        validatorsWithExtraProps[name] = extraProps;
+      }
+    });
+    if (Object.keys(validatorsWithExtraProps).length) {
+      throw new Error([
+        `Validators are only allowed to be functions or objects that have ${allowedProperties.join(', ')}.`,
+        `You provided some extra properties: ${JSON.stringify(validatorsWithExtraProps)}`
+      ].join(' '));
     }
   }
-};
+}
+
+export default formlyCustomValidation;

--- a/src/directives/formly-custom-validation.test.js
+++ b/src/directives/formly-custom-validation.test.js
@@ -1,3 +1,5 @@
+import {expect} from 'chai';
+
 describe(`formly-custom-validation`, function() {
   let $compile, $timeout, $q, scope;
   let formTemplate = `<form name="myForm">TEMPLATE</form>`;

--- a/src/directives/formly-custom-validation.test.js
+++ b/src/directives/formly-custom-validation.test.js
@@ -1,110 +1,108 @@
-module.exports = ngModule => {
-  describe(`formly-custom-validation`, function() {
-    let $compile, $timeout, $q, scope;
-    let formTemplate = `<form name="myForm">TEMPLATE</form>`;
-    beforeEach(window.module(ngModule.name));
-    beforeEach(inject((_$compile_, _$timeout_, _$q_, $rootScope) => {
-      $compile = _$compile_;
-      $timeout = _$timeout_;
-      $q = _$q_;
-      scope = $rootScope.$new();
-      scope.options = {validation:{}, validators: {}};
-    }));
+describe(`formly-custom-validation`, function() {
+  let $compile, $timeout, $q, scope;
+  let formTemplate = `<form name="myForm">TEMPLATE</form>`;
+  beforeEach(window.module('formly'));
+  beforeEach(inject((_$compile_, _$timeout_, _$q_, $rootScope) => {
+    $compile = _$compile_;
+    $timeout = _$timeout_;
+    $q = _$q_;
+    scope = $rootScope.$new();
+    scope.options = {validation:{}, validators: {}};
+  }));
 
-    describe(`using parsers`, () => {
-      checkApi(formTemplate.replace(
-        `TEMPLATE`, `<input ng-model="input" name="field" formly-custom-validation use-parsers />`
-      ), angular.version.minor >= 3);
-    });
+  describe(`using parsers`, () => {
+    checkApi(formTemplate.replace(
+      `TEMPLATE`, `<input ng-model="input" name="field" formly-custom-validation use-parsers />`
+    ), angular.version.minor >= 3);
+  });
 
-    describe(`using $validators`, () => {
-      checkApi(formTemplate.replace(
+  describe(`using $validators`, () => {
+    checkApi(formTemplate.replace(
+      `TEMPLATE`, `<input ng-model="input" name="field" formly-custom-validation />`
+    ));
+  });
+
+  describe(`options.validation.messages`, () => {
+    it(`should convert all strings to functions`, () => {
+      scope.options.validation = {
+        messages: {
+          isHello: `'"' + $viewValue + '" is not "hello"'`
+        }
+      };
+      $compile(formTemplate.replace(
         `TEMPLATE`, `<input ng-model="input" name="field" formly-custom-validation />`
-      ));
+      ))(scope);
+
+      expect(typeof scope.options.validation.messages.isHello).to.eq('function');
+      const field = scope.myForm.field;
+      field.$setViewValue('sup');
+      expect(scope.options.validation.messages.isHello()).to.eq('"sup" is not "hello"');
+    });
+  });
+
+  function checkApi(template, versionThreeOrBetterAndEmulating) {
+    const value = `hello`;
+    it(`should pass if returning a string that passes`, () => {
+      doValidation(`$viewValue === "${value}"`, true);
     });
 
-    describe(`options.validation.messages`, () => {
-      it(`should convert all strings to functions`, () => {
-        scope.options.validation = {
-          messages: {
-            isHello: `'"' + $viewValue + '" is not "hello"'`
-          }
-        };
-        $compile(formTemplate.replace(
-          `TEMPLATE`, `<input ng-model="input" name="field" formly-custom-validation />`
-        ))(scope);
-
-        expect(typeof scope.options.validation.messages.isHello).to.eq('function');
-        const field = scope.myForm.field;
-        field.$setViewValue('sup');
-        expect(scope.options.validation.messages.isHello()).to.eq('"sup" is not "hello"');
-      });
+    it(`should fail if returning a string that fails`, () => {
+      doValidation(`$viewValue !== "${value}"`, false);
     });
 
-    function checkApi(template, versionThreeOrBetterAndEmulating) {
-      const value = `hello`;
-      it(`should pass if returning a string that passes`, () => {
-        doValidation(`$viewValue === "${value}"`, true);
-      });
+    it(`should pass if it's a function that passes`, () => {
+      doValidation(viewValue => viewValue === value, true);
+    });
 
-      it(`should fail if returning a string that fails`, () => {
-        doValidation(`$viewValue !== "${value}"`, false);
-      });
+    it(`should fail if it's a function that fails`, () => {
+      doValidation(viewValue => viewValue !== value, false);
+    });
 
-      it(`should pass if it's a function that passes`, () => {
-        doValidation(viewValue => viewValue === value, true);
-      });
+    it(`should pass if it's a function that returns a promise that resolves`, () => {
+      doValidation(() => $q.when(), true);
+    });
 
-      it(`should fail if it's a function that fails`, () => {
-        doValidation(viewValue => viewValue !== value, false);
-      });
+    it(`should fail if it's a function that returns a promise that rejects`, () => {
+      doValidation(() => $q.reject(), false);
+    });
 
-      it(`should pass if it's a function that returns a promise that resolves`, () => {
-        doValidation(() => $q.when(), true);
-      });
+    it(`should be pending until the promise is resolved`, () => {
+      const deferred = $q.defer();
+      const deferred2 = $q.defer();
+      scope.options.validators.isHello = () => deferred.promise;
+      scope.options.validators.isHey = () => deferred2.promise;
+      $compile(template)(scope);
+      const field = scope.myForm.field;
+      scope.$digest();
+      field.$setViewValue(value);
 
-      it(`should fail if it's a function that returns a promise that rejects`, () => {
-        doValidation(() => $q.reject(), false);
-      });
+      expect(field.$pending).to.exist;
+      expect(field.$pending.isHello).to.be.true;
+      expect(field.$pending.isHey).to.be.true;
 
-      it(`should be pending until the promise is resolved`, () => {
-        const deferred = $q.defer();
-        const deferred2 = $q.defer();
-        scope.options.validators.isHello = () => deferred.promise;
-        scope.options.validators.isHey = () => deferred2.promise;
-        $compile(template)(scope);
-        const field = scope.myForm.field;
+      // because in angular 1.3 they do some interesting stuff with $pending, so can only test $pending in 1.2
+      if (!versionThreeOrBetterAndEmulating) {
+        deferred.resolve();
         scope.$digest();
-        field.$setViewValue(value);
 
         expect(field.$pending).to.exist;
-        expect(field.$pending.isHello).to.be.true;
         expect(field.$pending.isHey).to.be.true;
+        expect(field.$pending.isHello).to.not.exist;
 
-        // because in angular 1.3 they do some interesting stuff with $pending, so can only test $pending in 1.2
-        if (!versionThreeOrBetterAndEmulating) {
-          deferred.resolve();
-          scope.$digest();
-
-          expect(field.$pending).to.exist;
-          expect(field.$pending.isHey).to.be.true;
-          expect(field.$pending.isHello).to.not.exist;
-
-          deferred2.reject();
-          scope.$digest();
-          expect(field.$pending).to.not.exist;
-        }
-      });
-
-      function doValidation(validator, pass) {
-        scope.options.validators.isHello = validator;
-        $compile(template)(scope);
-        const field = scope.myForm.field;
+        deferred2.reject();
         scope.$digest();
-        field.$setViewValue(value);
-        scope.$digest();
-        expect(field.$valid).to.eq(pass);
+        expect(field.$pending).to.not.exist;
       }
+    });
+
+    function doValidation(validator, pass) {
+      scope.options.validators.isHello = validator;
+      $compile(template)(scope);
+      const field = scope.myForm.field;
+      scope.$digest();
+      field.$setViewValue(value);
+      scope.$digest();
+      expect(field.$valid).to.eq(pass);
     }
-  });
-};
+  }
+});

--- a/src/directives/formly-field.js
+++ b/src/directives/formly-field.js
@@ -1,368 +1,364 @@
-let angular = require('angular-fix');
+import angular from 'angular-fix';
 
-module.exports = ngModule => {
-  ngModule.directive('formlyField', formlyField);
+/**
+ * @ngdoc directive
+ * @name formlyField
+ * @restrict AE
+ */
+function formlyField($http, $q, $compile, $templateCache, formlyConfig, formlyValidationMessages, formlyApiCheck,
+                     formlyUtil, formlyUsability, formlyWarn) {
+  return {
+    restrict: 'AE',
+    transclude: true,
+    scope: {
+      options: '=',
+      model: '=',
+      formId: '@',
+      index: '=?',
+      fields: '=?',
+      formState: '=?',
+      form: '=?'
+    },
+    controller: function fieldController($scope, $timeout, $parse, $controller) {
+      var opts = $scope.options;
+      var fieldType = opts.type && formlyConfig.getType(opts.type);
+      simplifyLife(opts);
+      mergeFieldOptionsWithTypeDefaults(opts, fieldType);
+      extendOptionsWithDefaults(opts, $scope.index);
+      checkApi(opts);
+      // set field id to link labels and fields
+      $scope.id = formlyUtil.getFieldId($scope.formId, opts, $scope.index);
 
-  formlyField.tests = ON_TEST ? require('./formly-field.test')(ngModule) : null;
+      // initalization
+      runExpressions();
+      setFormControl($scope, opts);
+      addModelWatcher($scope, opts);
+      addValidationMessages(opts);
+      // simplify things
+      // create $scope.to so template authors can reference to instead of $scope.options.templateOptions
+      $scope.to = $scope.options.templateOptions;
+      invokeControllers($scope, opts, fieldType);
 
-  /**
-   * @ngdoc directive
-   * @name formlyField
-   * @restrict AE
-   */
-  function formlyField($http, $q, $compile, $templateCache, formlyConfig, formlyValidationMessages, formlyApiCheck,
-                       formlyUtil, formlyUsability, formlyWarn) {
-    return {
-      restrict: 'AE',
-      transclude: true,
-      scope: {
-        options: '=',
-        model: '=',
-        formId: '@',
-        index: '=?',
-        fields: '=?',
-        formState: '=?',
-        form: '=?'
-      },
-      controller: function fieldController($scope, $timeout, $parse, $controller) {
-        var opts = $scope.options;
-        var fieldType = opts.type && formlyConfig.getType(opts.type);
-        simplifyLife(opts);
-        mergeFieldOptionsWithTypeDefaults(opts, fieldType);
-        extendOptionsWithDefaults(opts, $scope.index);
-        checkApi(opts);
-        // set field id to link labels and fields
-        $scope.id = formlyUtil.getFieldId($scope.formId, opts, $scope.index);
-
-        // initalization
-        runExpressions();
-        setFormControl($scope, opts);
-        addModelWatcher($scope, opts);
-        addValidationMessages(opts);
-        // simplify things
-        // create $scope.to so template authors can reference to instead of $scope.options.templateOptions
-        $scope.to = $scope.options.templateOptions;
-        invokeControllers($scope, opts, fieldType);
-
-        // function definitions
-        function runExpressions() {
-          $timeout(function() { // must run on next tick to make sure that the current value is correct.
-            var field = $scope.options;
-            var currentValue = valueGetterSetter();
-            angular.forEach(field.expressionProperties, function runExpression(expression, prop) {
-              var setter = $parse(prop).assign;
-              var promise = $q.when(formlyUtil.formlyEval($scope, expression, currentValue));
-              promise.then(function(value) {
-                setter(field, value);
-              });
+      // function definitions
+      function runExpressions() {
+        $timeout(function() { // must run on next tick to make sure that the current value is correct.
+          var field = $scope.options;
+          var currentValue = valueGetterSetter();
+          angular.forEach(field.expressionProperties, function runExpression(expression, prop) {
+            var setter = $parse(prop).assign;
+            var promise = $q.when(formlyUtil.formlyEval($scope, expression, currentValue));
+            promise.then(function(value) {
+              setter(field, value);
             });
           });
-        }
+        });
+      }
 
-        function valueGetterSetter(newVal) {
-          if (!$scope.model || !$scope.options.key) {
-            return;
+      function valueGetterSetter(newVal) {
+        if (!$scope.model || !$scope.options.key) {
+          return;
+        }
+        if (angular.isDefined(newVal)) {
+          $scope.model[$scope.options.key] = newVal;
+        }
+        return $scope.model[$scope.options.key];
+      }
+
+      function simplifyLife(options) {
+        // add a few empty objects (if they don't already exist) so you don't have to undefined check everywhere
+        formlyUtil.reverseDeepMerge(options, {
+          data: {},
+          templateOptions: {},
+          validation: {}
+        });
+      }
+
+      function mergeFieldOptionsWithTypeDefaults(options, type) {
+        if (type) {
+          mergeOptions(options, type.defaultOptions);
+        }
+        var properOrder = arrayify(options.optionsTypes).reverse(); // so the right things are overridden
+        angular.forEach(properOrder, typeName => {
+          mergeOptions(options, formlyConfig.getType(typeName, true, options).defaultOptions);
+        });
+      }
+
+      function mergeOptions(options, extraOptions) {
+        if (extraOptions) {
+          if (angular.isFunction(extraOptions)) {
+            extraOptions = extraOptions(options);
           }
-          if (angular.isDefined(newVal)) {
-            $scope.model[$scope.options.key] = newVal;
-          }
-          return $scope.model[$scope.options.key];
-        }
-
-        function simplifyLife(options) {
-          // add a few empty objects (if they don't already exist) so you don't have to undefined check everywhere
-          formlyUtil.reverseDeepMerge(options, {
-            data: {},
-            templateOptions: {},
-            validation: {}
-          });
-        }
-
-        function mergeFieldOptionsWithTypeDefaults(options, type) {
-          if (type) {
-            mergeOptions(options, type.defaultOptions);
-          }
-          var properOrder = arrayify(options.optionsTypes).reverse(); // so the right things are overridden
-          angular.forEach(properOrder, typeName => {
-            mergeOptions(options, formlyConfig.getType(typeName, true, options).defaultOptions);
-          });
-        }
-
-        function mergeOptions(options, extraOptions) {
-          if (extraOptions) {
-            if (angular.isFunction(extraOptions)) {
-              extraOptions = extraOptions(options);
-            }
-            formlyUtil.reverseDeepMerge(options, extraOptions);
-          }
-        }
-
-        function extendOptionsWithDefaults(options, index) {
-          const key = options.key || index || 0;
-          const initialValue = $scope.model && $scope.model[key];
-          angular.extend(options, {
-            // attach the key in case the formly-field directive is used directly
-            key,
-            value: valueGetterSetter,
-            runExpressions,
-            resetModel,
-            updateInitialValue,
-            initialValue
-          });
-        }
-
-        // initialization functions
-        function setFormControl(scope, options) {
-          if (options.noFormControl) {
-            return;
-          }
-          scope.$watch('form["' + scope.id + '"]', function(formControl) {
-            if (formControl) {
-              scope.fc = formControl; // shortcut for template authors
-              scope.options.formControl = formControl;
-              addShowMessagesWatcher(scope, options);
-            }
-          });
-        }
-
-        function addModelWatcher(scope, options) {
-          if (options.model) {
-            scope.$watch('options.model', runExpressions, true);
-          }
-        }
-
-        function addShowMessagesWatcher(scope, options) {
-          scope.$watch(function() {
-            if (typeof scope.options.validation.show === 'boolean') {
-              return scope.fc.$invalid && scope.options.validation.show;
-            } else {
-              let noTouchedButDirty = (angular.isUndefined(scope.fc.$touched) && scope.fc.$dirty);
-              return scope.fc.$invalid && (scope.fc.$touched || noTouchedButDirty);
-            }
-          }, function(show) {
-            options.validation.errorExistsAndShouldBeVisible = show;
-            scope.showError = show; // shortcut for template authors
-          });
-        }
-
-        function resetModel() {
-          $scope.model[$scope.options.key] = $scope.options.initialValue;
-          if ($scope.options.formControl) {
-            $scope.options.formControl.$setViewValue($scope.model[$scope.options.key]);
-            $scope.options.formControl.$render();
-          }
-        }
-
-        function updateInitialValue() {
-          $scope.options.initialValue = $scope.model[$scope.options.key];
-        }
-
-        function addValidationMessages(options) {
-          options.validation.messages = options.validation.messages || {};
-          angular.forEach(formlyValidationMessages.messages, function(expression, name) {
-            if (!options.validation.messages[name]) {
-              options.validation.messages[name] = function(viewValue, modelValue, scope) {
-                return formlyUtil.formlyEval(scope, expression, modelValue, viewValue);
-              };
-            }
-          });
-        }
-
-        function invokeControllers(scope, options = {}, type = {}) {
-          angular.forEach([type.controller, options.controller], controller => {
-            if (controller) {
-              $controller(controller, {$scope: scope});
-            }
-          });
-        }
-      },
-      link: function fieldLink(scope, el) {
-        var type = scope.options.type && formlyConfig.getType(scope.options.type);
-        var args = arguments;
-        var thusly = this;
-        getFieldTemplate(scope.options)
-          .then(runManipulators(formlyConfig.templateManipulators.preWrapper))
-          .then(transcludeInWrappers(scope.options))
-          .then(runManipulators(formlyConfig.templateManipulators.postWrapper))
-          .then(setElementTemplate)
-          .catch(error => {
-            formlyWarn(
-              'there-was-a-problem-setting-the-template-for-this-field',
-              'There was a problem setting the template for this field ',
-              scope.options,
-              error
-            );
-          });
-
-        function setElementTemplate(templateEl) {
-          el.html(asHtml(templateEl));
-          $compile(el.contents())(scope);
-          if (type && type.link) {
-            type.link.apply(thusly, args);
-          }
-          if (scope.options.link) {
-            scope.options.link.apply(thusly, args);
-          }
-        }
-
-        function runManipulators(manipulators) {
-          return function runManipulatorsOnTemplate(template) {
-            var chain = $q.when(template);
-            angular.forEach(manipulators, manipulator => {
-              chain = chain.then(template => {
-                return $q.when(manipulator(template, scope.options, scope)).then(newTemplate => {
-                  return angular.isString(newTemplate) ? newTemplate : asHtml(newTemplate);
-                });
-              });
-            });
-            return chain;
-          };
+          formlyUtil.reverseDeepMerge(options, extraOptions);
         }
       }
-    };
 
-    function asHtml(el) {
-      var wrapper = angular.element('<a></a>');
-      return wrapper.append(el).html();
-    }
-
-    function getFieldTemplate(options) {
-      let type = formlyConfig.getType(options.type, true, options);
-      let template = options.template || type && type.template;
-      let templateUrl = options.templateUrl || type && type.templateUrl;
-      if (!template && !templateUrl) {
-        throw formlyUsability.getFieldError(
-          'type-type-has-no-template',
-          `Type '${options.type}' has not template. On element:`, options
-        );
+      function extendOptionsWithDefaults(options, index) {
+        const key = options.key || index || 0;
+        const initialValue = $scope.model && $scope.model[key];
+        angular.extend(options, {
+          // attach the key in case the formly-field directive is used directly
+          key,
+          value: valueGetterSetter,
+          runExpressions,
+          resetModel,
+          updateInitialValue,
+          initialValue
+        });
       }
-      return getTemplate(template || templateUrl, !template);
-    }
 
+      // initialization functions
+      function setFormControl(scope, options) {
+        if (options.noFormControl) {
+          return;
+        }
+        scope.$watch('form["' + scope.id + '"]', function(formControl) {
+          if (formControl) {
+            scope.fc = formControl; // shortcut for template authors
+            scope.options.formControl = formControl;
+            addShowMessagesWatcher(scope, options);
+          }
+        });
+      }
 
-    function getTemplate(template, isUrl) {
-      if (!isUrl) {
-        return $q.when(template);
-      } else {
-        let httpOptions = {cache: $templateCache};
-        return $http.get(template, httpOptions).then(function(response) {
-          return response.data;
-        }).catch(function(error) {
+      function addModelWatcher(scope, options) {
+        if (options.model) {
+          scope.$watch('options.model', runExpressions, true);
+        }
+      }
+
+      function addShowMessagesWatcher(scope, options) {
+        scope.$watch(function() {
+          if (typeof scope.options.validation.show === 'boolean') {
+            return scope.fc.$invalid && scope.options.validation.show;
+          } else {
+            let noTouchedButDirty = (angular.isUndefined(scope.fc.$touched) && scope.fc.$dirty);
+            return scope.fc.$invalid && (scope.fc.$touched || noTouchedButDirty);
+          }
+        }, function(show) {
+          options.validation.errorExistsAndShouldBeVisible = show;
+          scope.showError = show; // shortcut for template authors
+        });
+      }
+
+      function resetModel() {
+        $scope.model[$scope.options.key] = $scope.options.initialValue;
+        if ($scope.options.formControl) {
+          $scope.options.formControl.$setViewValue($scope.model[$scope.options.key]);
+          $scope.options.formControl.$render();
+        }
+      }
+
+      function updateInitialValue() {
+        $scope.options.initialValue = $scope.model[$scope.options.key];
+      }
+
+      function addValidationMessages(options) {
+        options.validation.messages = options.validation.messages || {};
+        angular.forEach(formlyValidationMessages.messages, function(expression, name) {
+          if (!options.validation.messages[name]) {
+            options.validation.messages[name] = function(viewValue, modelValue, scope) {
+              return formlyUtil.formlyEval(scope, expression, modelValue, viewValue);
+            };
+          }
+        });
+      }
+
+      function invokeControllers(scope, options = {}, type = {}) {
+        angular.forEach([type.controller, options.controller], controller => {
+          if (controller) {
+            $controller(controller, {$scope: scope});
+          }
+        });
+      }
+    },
+    link: function fieldLink(scope, el) {
+      var type = scope.options.type && formlyConfig.getType(scope.options.type);
+      var args = arguments;
+      var thusly = this;
+      getFieldTemplate(scope.options)
+        .then(runManipulators(formlyConfig.templateManipulators.preWrapper))
+        .then(transcludeInWrappers(scope.options))
+        .then(runManipulators(formlyConfig.templateManipulators.postWrapper))
+        .then(setElementTemplate)
+        .catch(error => {
           formlyWarn(
-            'problem-loading-template-for-templateurl',
-            'Problem loading template for ' + template,
+            'there-was-a-problem-setting-the-template-for-this-field',
+            'There was a problem setting the template for this field ',
+            scope.options,
             error
           );
         });
-      }
-    }
 
-    function transcludeInWrappers(options) {
-      let wrapper = getWrapperOption(options);
-
-      return function transcludeTemplate(template) {
-        if (!wrapper.length) {
-          return $q.when(template);
+      function setElementTemplate(templateEl) {
+        el.html(asHtml(templateEl));
+        $compile(el.contents())(scope);
+        if (type && type.link) {
+          type.link.apply(thusly, args);
         }
-
-        wrapper.forEach((wrapper) => {
-          formlyUsability.checkWrapper(wrapper, options);
-          wrapper.validateOptions && wrapper.validateOptions(options);
-          runApiCheck(wrapper, options);
-        });
-        let promises = wrapper.map(w => getTemplate(w.template || w.templateUrl, !w.template));
-        return $q.all(promises).then(wrappersTemplates => {
-          wrappersTemplates.forEach((wrapperTemplate, index) => {
-            formlyUsability.checkWrapperTemplate(wrapperTemplate, wrapper[index]);
-          });
-          wrappersTemplates.reverse(); // wrapper 0 is wrapped in wrapper 1 and so on...
-          let totalWrapper = wrappersTemplates.shift();
-          wrappersTemplates.forEach(wrapperTemplate => {
-            totalWrapper = doTransclusion(totalWrapper, wrapperTemplate);
-          });
-          return doTransclusion(totalWrapper, template);
-        });
-      };
-    }
-
-    function doTransclusion(wrapper, template) {
-      let superWrapper = angular.element('<a></a>'); // this allows people not have to have a single root in wrappers
-      superWrapper.append(wrapper);
-      let transcludeEl = superWrapper.find('formly-transclude');
-      if (!transcludeEl.length) {
-        //try it using our custom find function
-        transcludeEl = formlyUtil.findByNodeName(superWrapper, 'formly-transclude');
-      }
-      transcludeEl.replaceWith(template);
-      return superWrapper.html();
-    }
-
-    function getWrapperOption(options) {
-      let wrapper = options.wrapper;
-      // explicit null means no wrapper
-      if (wrapper === null) {
-        return [];
-      }
-
-      // nothing specified means use the default wrapper for the type
-      if (!wrapper) {
-        // get all wrappers that specify they apply to this type
-        wrapper = arrayify(formlyConfig.getWrapperByType(options.type));
-      } else {
-        wrapper = arrayify(wrapper).map(formlyConfig.getWrapper);
-      }
-
-      // get all wrappers for that this type specified that it uses.
-      var type = formlyConfig.getType(options.type, true, options);
-      if (type && type.wrapper) {
-        let typeWrappers = arrayify(type.wrapper).map(formlyConfig.getWrapper);
-        wrapper = wrapper.concat(typeWrappers);
-      }
-
-      // add the default wrapper last
-      var defaultWrapper = formlyConfig.getWrapper();
-      if (defaultWrapper) {
-        wrapper.push(defaultWrapper);
-      }
-      return wrapper;
-    }
-
-    function checkApi(options) {
-      formlyApiCheck.throw(formlyApiCheck.formlyFieldOptions, options, {
-        prefix: 'formly-field directive',
-        url: 'formly-field-directive-validation-failed'
-      });
-      // validate with the type
-      const type = options.type && formlyConfig.getType(options.type);
-      if (type) {
-        if (type.validateOptions) {
-          type.validateOptions(options);
+        if (scope.options.link) {
+          scope.options.link.apply(thusly, args);
         }
-        runApiCheck(type, options);
+      }
+
+      function runManipulators(manipulators) {
+        return function runManipulatorsOnTemplate(template) {
+          var chain = $q.when(template);
+          angular.forEach(manipulators, manipulator => {
+            chain = chain.then(template => {
+              return $q.when(manipulator(template, scope.options, scope)).then(newTemplate => {
+                return angular.isString(newTemplate) ? newTemplate : asHtml(newTemplate);
+              });
+            });
+          });
+          return chain;
+        };
       }
     }
+  };
 
-    function runApiCheck({apiCheck, apiCheckInstance, apiCheckFunction, apiCheckOptions}, options) {
-      if (!apiCheck) {
-        return;
-      }
-      const instance = apiCheckInstance || formlyApiCheck;
-      const fn = apiCheckFunction || 'warn';
-      const shape = instance.shape(apiCheck);
-      instance[fn](shape, options, apiCheckOptions || {
-        prefix: `formly-field ${name}`,
-        url: formlyApiCheck.config.output.docsBaseUrl + 'formly-field-type-apicheck-failed'
-      });
-    }
-
+  function asHtml(el) {
+    var wrapper = angular.element('<a></a>');
+    return wrapper.append(el).html();
   }
 
-  function arrayify(obj) {
-    if (obj && !angular.isArray(obj)) {
-      obj = [obj];
-    } else if (!obj) {
-      obj = [];
+  function getFieldTemplate(options) {
+    let type = formlyConfig.getType(options.type, true, options);
+    let template = options.template || type && type.template;
+    let templateUrl = options.templateUrl || type && type.templateUrl;
+    if (!template && !templateUrl) {
+      throw formlyUsability.getFieldError(
+        'type-type-has-no-template',
+        `Type '${options.type}' has not template. On element:`, options
+      );
     }
-    return obj;
+    return getTemplate(template || templateUrl, !template);
   }
-};
+
+
+  function getTemplate(template, isUrl) {
+    if (!isUrl) {
+      return $q.when(template);
+    } else {
+      let httpOptions = {cache: $templateCache};
+      return $http.get(template, httpOptions).then(function(response) {
+        return response.data;
+      }).catch(function(error) {
+        formlyWarn(
+          'problem-loading-template-for-templateurl',
+          'Problem loading template for ' + template,
+          error
+        );
+      });
+    }
+  }
+
+  function transcludeInWrappers(options) {
+    let wrapper = getWrapperOption(options);
+
+    return function transcludeTemplate(template) {
+      if (!wrapper.length) {
+        return $q.when(template);
+      }
+
+      wrapper.forEach((wrapper) => {
+        formlyUsability.checkWrapper(wrapper, options);
+        wrapper.validateOptions && wrapper.validateOptions(options);
+        runApiCheck(wrapper, options);
+      });
+      let promises = wrapper.map(w => getTemplate(w.template || w.templateUrl, !w.template));
+      return $q.all(promises).then(wrappersTemplates => {
+        wrappersTemplates.forEach((wrapperTemplate, index) => {
+          formlyUsability.checkWrapperTemplate(wrapperTemplate, wrapper[index]);
+        });
+        wrappersTemplates.reverse(); // wrapper 0 is wrapped in wrapper 1 and so on...
+        let totalWrapper = wrappersTemplates.shift();
+        wrappersTemplates.forEach(wrapperTemplate => {
+          totalWrapper = doTransclusion(totalWrapper, wrapperTemplate);
+        });
+        return doTransclusion(totalWrapper, template);
+      });
+    };
+  }
+
+  function doTransclusion(wrapper, template) {
+    let superWrapper = angular.element('<a></a>'); // this allows people not have to have a single root in wrappers
+    superWrapper.append(wrapper);
+    let transcludeEl = superWrapper.find('formly-transclude');
+    if (!transcludeEl.length) {
+      //try it using our custom find function
+      transcludeEl = formlyUtil.findByNodeName(superWrapper, 'formly-transclude');
+    }
+    transcludeEl.replaceWith(template);
+    return superWrapper.html();
+  }
+
+  function getWrapperOption(options) {
+    let wrapper = options.wrapper;
+    // explicit null means no wrapper
+    if (wrapper === null) {
+      return [];
+    }
+
+    // nothing specified means use the default wrapper for the type
+    if (!wrapper) {
+      // get all wrappers that specify they apply to this type
+      wrapper = arrayify(formlyConfig.getWrapperByType(options.type));
+    } else {
+      wrapper = arrayify(wrapper).map(formlyConfig.getWrapper);
+    }
+
+    // get all wrappers for that this type specified that it uses.
+    var type = formlyConfig.getType(options.type, true, options);
+    if (type && type.wrapper) {
+      let typeWrappers = arrayify(type.wrapper).map(formlyConfig.getWrapper);
+      wrapper = wrapper.concat(typeWrappers);
+    }
+
+    // add the default wrapper last
+    var defaultWrapper = formlyConfig.getWrapper();
+    if (defaultWrapper) {
+      wrapper.push(defaultWrapper);
+    }
+    return wrapper;
+  }
+
+  function checkApi(options) {
+    formlyApiCheck.throw(formlyApiCheck.formlyFieldOptions, options, {
+      prefix: 'formly-field directive',
+      url: 'formly-field-directive-validation-failed'
+    });
+    // validate with the type
+    const type = options.type && formlyConfig.getType(options.type);
+    if (type) {
+      if (type.validateOptions) {
+        type.validateOptions(options);
+      }
+      runApiCheck(type, options);
+    }
+  }
+
+  function runApiCheck({apiCheck, apiCheckInstance, apiCheckFunction, apiCheckOptions}, options) {
+    if (!apiCheck) {
+      return;
+    }
+    const instance = apiCheckInstance || formlyApiCheck;
+    const fn = apiCheckFunction || 'warn';
+    const shape = instance.shape(apiCheck);
+    instance[fn](shape, options, apiCheckOptions || {
+      prefix: `formly-field ${name}`,
+      url: formlyApiCheck.config.output.docsBaseUrl + 'formly-field-type-apicheck-failed'
+    });
+  }
+
+}
+
+function arrayify(obj) {
+  if (obj && !angular.isArray(obj)) {
+    obj = [obj];
+  } else if (!obj) {
+    obj = [];
+  }
+  return obj;
+}
+
+export default formlyField;

--- a/src/directives/formly-field.js
+++ b/src/directives/formly-field.js
@@ -5,7 +5,7 @@ import angular from 'angular-fix';
  * @name formlyField
  * @restrict AE
  */
-function formlyField($http, $q, $compile, $templateCache, formlyConfig, formlyValidationMessages, formlyApiCheck,
+export default function formlyField($http, $q, $compile, $templateCache, formlyConfig, formlyValidationMessages, formlyApiCheck,
                      formlyUtil, formlyUsability, formlyWarn) {
   return {
     restrict: 'AE',
@@ -360,5 +360,3 @@ function arrayify(obj) {
   }
   return obj;
 }
-
-export default formlyField;

--- a/src/directives/formly-field.test.js
+++ b/src/directives/formly-field.test.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 import apiCheck from 'api-check';
+import {expect} from 'chai';
 
 describe('formly-field', function() {
   let $compile, scope, formlyConfig;

--- a/src/directives/formly-field.test.js
+++ b/src/directives/formly-field.test.js
@@ -1,461 +1,460 @@
-const sinon = require('sinon');
-const apiCheck = require('api-check');
-module.exports = ngModule => {
-  describe('formly-field', function() {
-    let $compile, scope, formlyConfig;
-    let template = '<formly-form form="theForm" model="model" fields="fields"></formly-form>';
-    beforeEach(window.module(ngModule.name));
-    beforeEach(inject((_$compile_, $rootScope, _formlyConfig_) => {
-      $compile = _$compile_;
-      scope = $rootScope.$new();
-      formlyConfig = _formlyConfig_;
-    }));
+import sinon from 'sinon';
+import apiCheck from 'api-check';
 
-    describe('with template wrapper', function() {
-      beforeEach(() => {
-        formlyConfig.setWrapper([
-          {
-            types: 'text',
-            template: `
-              <div class="my-template-wrapper">
-                <label for="{{id}}">{{options.label}}</label>
-                <formly-transclude></formly-transclude>
+describe('formly-field', function() {
+  let $compile, scope, formlyConfig;
+  let template = '<formly-form form="theForm" model="model" fields="fields"></formly-form>';
+  beforeEach(window.module('formly'));
+  beforeEach(inject((_$compile_, $rootScope, _formlyConfig_) => {
+    $compile = _$compile_;
+    scope = $rootScope.$new();
+    formlyConfig = _formlyConfig_;
+  }));
+
+  describe('with template wrapper', function() {
+    beforeEach(() => {
+      formlyConfig.setWrapper([
+        {
+          types: 'text',
+          template: `
+            <div class="my-template-wrapper">
+              <label for="{{id}}">{{options.label}}</label>
+              <formly-transclude></formly-transclude>
+            </div>
+          `
+        },
+        {
+          types: 'other',
+          template: `
+            <div class="my-other-template-wrapper">
+              <formly-transclude></formly-transclude>
+              <div>
+                This is great for ng-messages
               </div>
-            `
+            </div>
+          `
+        }
+      ]);
+      formlyConfig.setType({
+        name: 'text', template: `<input name="{{id}}" ng-model="model[options.key]" />`
+      });
+      scope.model = {};
+    });
+
+    it('should take the entire wrapper, not just the contents of the wrapper', function() {
+      scope.fields = [
+        {
+          type: 'text',
+          key: 'text',
+          templateOptions: {
+            label: 'Text input'
+          }
+        }
+      ];
+      const el = compileAndDigest();
+      expect(el[0].querySelector('.my-template-wrapper')).to.exist;
+    });
+
+    it('should wrap arrays of wrappers', () => {
+      scope.fields = [
+        {
+          type: 'text',
+          key: 'text',
+          wrapper: ['text', 'other'],
+          templateOptions: {
+            label: 'Text input'
+          }
+        }
+      ];
+      const el = compileAndDigest();
+      var outerEl = el[0].querySelector('.my-other-template-wrapper');
+      expect(outerEl).to.exist;
+      expect(outerEl.querySelector('.my-template-wrapper')).to.exist;
+    });
+
+    it(`should allow for specifying null for the wrappers of a field`, () => {
+      scope.fields = [
+        {
+          type: 'text',
+          key: 'text',
+          wrapper: null,
+          templateOptions: {
+            label: 'Text input'
+          }
+        }
+      ];
+      const el = compileAndDigest();
+      expect(el[0].querySelector('.my-template-wrapper')).to.not.exist;
+    });
+
+  });
+
+
+  describe('api check', () => {
+    let validateOptions;
+    beforeEach(() => {
+      validateOptions = sinon.spy();
+      formlyConfig.setType({
+        name: 'text', template: `<input name="{{id}}" ng-model="model[options.key]" />`,
+        validateOptions
+      });
+      scope.model = {};
+    });
+
+    it('should throw an error when a field has extra properties', () => {
+      scope.fields = [
+        {
+          type: 'text',
+          extraProp: 'whatever'
+        }
+      ];
+
+
+      expect(() => compileAndDigest()).to.throw(/extra.*properties.*extraProp/);
+    });
+
+    it(`should invoke the validateOptions property of the type`, () => {
+      const field = {type: 'text'};
+      scope.fields = [field];
+      compileAndDigest();
+      expect(validateOptions).to.have.been.calledWith(field);
+    });
+  });
+
+  describe('default type options', () => {
+    beforeEach(() => {
+      scope.model = {};
+      formlyConfig.setType({
+        name: 'ipAddress', template: '<input name="{{id}}" ng-model="model[options.key]" />',
+        defaultOptions: {
+          data: {
+            usingDefaultOptions: true
           },
-          {
-            types: 'other',
-            template: `
-              <div class="my-other-template-wrapper">
-                <formly-transclude></formly-transclude>
-                <div>
-                  This is great for ng-messages
-                </div>
-              </div>
-            `
-          }
-        ]);
-        formlyConfig.setType({
-          name: 'text', template: `<input name="{{id}}" ng-model="model[options.key]" />`
-        });
-        scope.model = {};
-      });
-
-      it('should take the entire wrapper, not just the contents of the wrapper', function() {
-        scope.fields = [
-          {
-            type: 'text',
-            key: 'text',
-            templateOptions: {
-              label: 'Text input'
+          validators: {
+            ipAddress: function(viewValue, modelValue) {
+              var value = modelValue || viewValue;
+              return /(\d{1,3}\.){3}\d{1,3}/.test(value);
             }
           }
-        ];
-        const el = compileAndDigest();
-        expect(el[0].querySelector('.my-template-wrapper')).to.exist;
+        }
       });
 
-      it('should wrap arrays of wrappers', () => {
-        scope.fields = [
-          {
-            type: 'text',
-            key: 'text',
-            wrapper: ['text', 'other'],
-            templateOptions: {
-              label: 'Text input'
+      formlyConfig.setType({
+        name: 'text', template: '<input name="{{id}}" ng-model="model[options.key]" />',
+        defaultOptions: {
+          data: {
+            hasPropertiesFromTextType: true
+          }
+        }
+      });
+      formlyConfig.setType({
+        name: 'phone',
+        defaultOptions: {
+          ngModelAttrs: {
+            '/^1[2-9]\\d{2}[2-9]\\d{6}$/': {
+              value: 'ng-pattern'
             }
           }
-        ];
-        const el = compileAndDigest();
-        var outerEl = el[0].querySelector('.my-other-template-wrapper');
-        expect(outerEl).to.exist;
-        expect(outerEl.querySelector('.my-template-wrapper')).to.exist;
+        }
       });
-
-      it(`should allow for specifying null for the wrappers of a field`, () => {
-        scope.fields = [
-          {
-            type: 'text',
-            key: 'text',
-            wrapper: null,
-            templateOptions: {
-              label: 'Text input'
-            }
-          }
-        ];
-        const el = compileAndDigest();
-        expect(el[0].querySelector('.my-template-wrapper')).to.not.exist;
-      });
-
-    });
-
-
-    describe('api check', () => {
-      let validateOptions;
-      beforeEach(() => {
-        validateOptions = sinon.spy();
-        formlyConfig.setType({
-          name: 'text', template: `<input name="{{id}}" ng-model="model[options.key]" />`,
-          validateOptions
-        });
-        scope.model = {};
-      });
-
-      it('should throw an error when a field has extra properties', () => {
-        scope.fields = [
-          {
-            type: 'text',
-            extraProp: 'whatever'
-          }
-        ];
-
-
-        expect(() => compileAndDigest()).to.throw(/extra.*properties.*extraProp/);
-      });
-
-      it(`should invoke the validateOptions property of the type`, () => {
-        const field = {type: 'text'};
-        scope.fields = [field];
-        compileAndDigest();
-        expect(validateOptions).to.have.been.calledWith(field);
-      });
-    });
-
-    describe('default type options', () => {
-      beforeEach(() => {
-        scope.model = {};
-        formlyConfig.setType({
-          name: 'ipAddress', template: '<input name="{{id}}" ng-model="model[options.key]" />',
-          defaultOptions: {
-            data: {
-              usingDefaultOptions: true
+      formlyConfig.setType({
+        name: 'required',
+        defaultOptions: {
+          ngModelAttrs: {
+            '/overwriting stuff is fun for tests/': {
+              value: 'ng-pattern'
             },
-            validators: {
-              ipAddress: function(viewValue, modelValue) {
-                var value = modelValue || viewValue;
-                return /(\d{1,3}\.){3}\d{1,3}/.test(value);
-              }
-            }
-          }
-        });
-
-        formlyConfig.setType({
-          name: 'text', template: '<input name="{{id}}" ng-model="model[options.key]" />',
-          defaultOptions: {
-            data: {
-              hasPropertiesFromTextType: true
-            }
-          }
-        });
-        formlyConfig.setType({
-          name: 'phone',
-          defaultOptions: {
-            ngModelAttrs: {
-              '/^1[2-9]\\d{2}[2-9]\\d{6}$/': {
-                value: 'ng-pattern'
-              }
-            }
-          }
-        });
-        formlyConfig.setType({
-          name: 'required',
-          defaultOptions: {
-            ngModelAttrs: {
-              '/overwriting stuff is fun for tests/': {
-                value: 'ng-pattern'
-              },
-              required: {
-                bound: 'ng-required',
-                attribute: 'required'
-              },
-              myChange: {
-                expression: 'ng-change'
-              }
+            required: {
+              bound: 'ng-required',
+              attribute: 'required'
             },
-            templateOptions: {
-              required: true
+            myChange: {
+              expression: 'ng-change'
             }
-          }
-        });
-      });
-
-      it('should default to the ipAddress type options', () => {
-        var field = {type: 'ipAddress'};
-        scope.fields = [field];
-        compileAndDigest();
-        expect(field.data.usingDefaultOptions).to.be.true;
-        expect(field.validators.ipAddress).to.be.a('function');
-      });
-
-      it('should be possible to specify defaultOptions-only types (non-template types)', () => {
-        const field = {
-          type: 'text', optionsTypes: ['phone', 'required'], templateOptions: {myChange: 'model.otherThing = true'}
-        };
-        scope.fields = [field];
-        const el = compileAndDigest();
-        const input = el.find('input');
-        expect(field.data.hasPropertiesFromTextType).to.be.true;
-        expect(input.attr('ng-pattern')).to.equal('/overwriting stuff is fun for tests/');
-        expect(input.attr('ng-change')).to.contain('myChange');
-      });
-    });
-
-
-    describe('templateManipulators', () => {
-      testTemplateManipulators(true);
-      testTemplateManipulators(false);
-
-      function testTemplateManipulators(isPre) {
-        describe(isPre ? 'preWrapper' : 'postWrapper', () => {
-          var manipulators;
-          var textTemplate = '<input class="text-template" name="{{id}}" ng-model="model[options.key]">';
-          beforeEach(() => {
-            manipulators = formlyConfig.templateManipulators[isPre ? 'preWrapper' : 'postWrapper'];
-            formlyConfig.setWrapper([
-              {
-                types: 'text',
-                template: '<div class="my-template-wrapper"><formly-transclude></formly-transclude></div>'
-              }
-            ]);
-            formlyConfig.setType({
-              name: 'text', template: textTemplate
-            });
-            scope.model = {};
-            scope.fields = [
-              {type: 'text'}
-            ];
-          });
-
-          var when = isPre ? 'before' : 'after';
-
-          it(`should call the manipulators when compiling a field ${when} the element is wrapped in wrappers`, () => {
-            var manipulatedTemplate;
-            manipulators.push((templateToManipulate, fieldOptions, scope) => {
-              if (isPre) {
-                expect(templateToManipulate).to.contain('text-template');
-              }
-              expect(fieldOptions).to.equal(scope.fields[0]);
-              expect(scope.options).to.equal(fieldOptions);
-              if (isPre) {
-                expect(templateToManipulate).to.not.contain('my-template-wrapper');
-              } else {
-                expect(templateToManipulate).to.contain('my-template-wrapper');
-              }
-              manipulatedTemplate = angular.element(templateToManipulate).addClass('manipulated');
-              return manipulatedTemplate;
-            });
-
-            manipulators.push((templateToManipulate, fieldOptions, scope) => {
-              if (isPre) {
-                expect(asHtml(manipulatedTemplate)).to.equal(templateToManipulate);
-              }
-              expect(fieldOptions).to.equal(scope.fields[0]);
-              expect(scope.options).to.equal(fieldOptions);
-              if (isPre) {
-                expect(templateToManipulate).to.not.contain('my-template-wrapper');
-              } else {
-                expect(templateToManipulate).to.contain('my-template-wrapper');
-              }
-              expect(templateToManipulate).to.contain('manipulated');
-              return angular.element(templateToManipulate).addClass('manipulated-twice');
-            });
-            var el = $compile(angular.element(template))(scope);
-            scope.$digest();
-            expect(el[0].querySelector('.manipulated')).to.exist;
-            expect(el[0].querySelector('.manipulated-twice')).to.exist;
-
-            function asHtml(el) {
-              return angular.element('<a></a>').append(el).html();
-            }
-          });
-        });
-      }
-    });
-
-    describe('type controllers and link functions', () => {
-      let controllerFn, linkFn;
-      beforeEach(() => {
-        controllerFn = function($scope) {
-          $scope.setInTypeController = true;
-        };
-
-        linkFn = function(scope, el, attrs) {
-          scope.setInTypeLink = true;
-          scope.el = el;
-          scope.attrs = attrs;
-        };
-
-        formlyConfig.setType({
-          name: 'text',
-          template: `<input name="{{id}}" ng-model="model[options.key]" />`,
-          controller: ['$scope', controllerFn],
-          link: linkFn
-        });
-        scope.model = {};
-      });
-      it('should run the controller function of a type', () => {
-        scope.fields = [
-          {type: 'text'}
-        ];
-        const el = compileAndDigest();
-        var fieldEl = angular.element(el[0].querySelector('.formly-field'));
-        expect(fieldEl.isolateScope().setInTypeController).to.be.true;
-      });
-
-      it('should run the link function of a type', () => {
-        scope.fields = [
-          {type: 'text'}
-        ];
-        const el = compileAndDigest();
-        var fieldEl = angular.element(el[0].querySelector('.formly-field'));
-        var fieldScope = fieldEl.isolateScope();
-        expect(fieldScope.setInTypeLink).to.be.true;
-        expect(fieldScope.el[0]).to.equal(fieldEl[0]);
-      });
-
-      it('should run the controller of the specific field', () => {
-        scope.fields = [
-          {template: 'sweet mercy', controller: ['$scope', controllerFn]}
-        ];
-
-        const el = compileAndDigest();
-        var fieldEl = angular.element(el[0].querySelector('.formly-field'));
-        expect(fieldEl.isolateScope().setInTypeController).to.be.true;
-      });
-
-
-      it('should run the link function of a type', () => {
-        scope.fields = [
-          {template: 'sweet mercy', link: linkFn}
-        ];
-        const el = compileAndDigest();
-        var fieldEl = angular.element(el[0].querySelector('.formly-field'));
-        var fieldScope = fieldEl.isolateScope();
-        expect(fieldScope.setInTypeLink).to.be.true;
-        expect(fieldScope.el[0]).to.equal(fieldEl[0]);
-      });
-    });
-
-    describe(`type apiCheck`, () => {
-      let type = 'input';
-      beforeEach(() => {
-        formlyConfig.setType({
-          name: type,
-          template: '<label>{{to.label}}</label><input class="{{to.className}}" ng-model="model[options.key]" />',
-          apiCheck: {
-            templateOptions: apiCheck.shape({
-              label: apiCheck.string,
-              className: apiCheck.string
-            })
           },
-          apiCheckInstance: apiCheck({
-            output: {prefix: 'custom-api-check'}
-          }),
-          apiCheckOptions: {
-            prefix: type + ' type checker',
-            url: 'http://example.com/some-custom-url'
+          templateOptions: {
+            required: true
           }
-        });
-        scope.model = {};
-      });
-
-      it(`should not warn if everything's fine`, () => {
-        scope.fields = [
-          {type, templateOptions: {label: 'string', className: 'string'}}
-        ];
-        shouldNotWarn(compileAndDigest);
-      });
-
-      it(`should warn if everything's not fine`, () => {
-        scope.fields = [
-          {type, templateOptions: {label: 'string'}}
-        ];
-        shouldWarn(
-          /custom-api-check.*?input type checker.*?some-custom-url(.|\n)*?className/,
-          compileAndDigest
-        );
-      });
-
-      it(`should throw if the apiCheckFunction is set to "throw" and everything's not fine`, () => {
-        formlyConfig.getType(type).apiCheckFunction = 'throw';
-        scope.fields = [
-          {type, templateOptions: {label: 'string'}}
-        ];
-        expect(compileAndDigest).to.throw(
-          /custom-api-check.*?input type checker.*?some-custom-url(.|\n)*?className/
-        );
+        }
       });
     });
 
-    describe(`wrapper apiCheck`, () => {
-      const name = 'input';
-      const template = '<input ng-model="model[options.key]" />';
-      const wrapper = name;
-      beforeEach(() => {
-        formlyConfig.setWrapper({
-          name,
-          template:
-            '<div class="to.className"><label>{{to.label}}</label><formly-transclude></formly-transclude></div>',
-          apiCheck: {
-            templateOptions: apiCheck.shape({
-              label: apiCheck.string,
-              className: apiCheck.string
-            })
-          },
-          apiCheckInstance: apiCheck({
-            output: {prefix: 'custom-api-check'}
-          })
-        });
-        scope.model = {};
-      });
-
-      it(`should not warn if everything's fine`, () => {
-        scope.fields = [
-          {template, wrapper, templateOptions: {label: 'string', className: 'string'}}
-        ];
-        shouldNotWarn(compileAndDigest);
-      });
-
-      it(`should warn if everything's not fine`, () => {
-        scope.fields = [
-          {template, wrapper, templateOptions: {label: 'string'}}
-        ];
-        shouldWarn(/custom-api-check.*?formly-field(.|\n)*?className/, compileAndDigest);
-      });
-
-      it(`should throw if the apiCheckFunction is set to "throw" and everything's not fine`, () => {
-        formlyConfig.getWrapper(name).apiCheckFunction = 'throw';
-        scope.fields = [
-          {template, wrapper, templateOptions: {label: 'string'}}
-        ];
-        expect(compileAndDigest).to.throw(/custom-api-check.*?formly-field(.|\n)*?className/);
-      });
+    it('should default to the ipAddress type options', () => {
+      var field = {type: 'ipAddress'};
+      scope.fields = [field];
+      compileAndDigest();
+      expect(field.data.usingDefaultOptions).to.be.true;
+      expect(field.validators.ipAddress).to.be.a('function');
     });
 
-    function compileAndDigest() {
-      const el = $compile(template)(scope);
-      scope.$digest();
-      return el;
-    }
-
-    function shouldWarn(match, test) {
-      var originalWarn = console.warn;
-      var calledArgs;
-      console.warn = function() {
-        calledArgs = arguments;
+    it('should be possible to specify defaultOptions-only types (non-template types)', () => {
+      const field = {
+        type: 'text', optionsTypes: ['phone', 'required'], templateOptions: {myChange: 'model.otherThing = true'}
       };
-      test();
-      expect(calledArgs[0]).to.match(match);
-      console.warn = originalWarn;
-    }
+      scope.fields = [field];
+      const el = compileAndDigest();
+      const input = el.find('input');
+      expect(field.data.hasPropertiesFromTextType).to.be.true;
+      expect(input.attr('ng-pattern')).to.equal('/overwriting stuff is fun for tests/');
+      expect(input.attr('ng-change')).to.contain('myChange');
+    });
+  });
 
-    function shouldNotWarn(test) {
-      var originalWarn = console.warn;
-      var callCount = 0;
-      console.warn = () => callCount++;
-      test();
-      expect(callCount).to.equal(0);
-      console.warn = originalWarn;
+
+  describe('templateManipulators', () => {
+    testTemplateManipulators(true);
+    testTemplateManipulators(false);
+
+    function testTemplateManipulators(isPre) {
+      describe(isPre ? 'preWrapper' : 'postWrapper', () => {
+        var manipulators;
+        var textTemplate = '<input class="text-template" name="{{id}}" ng-model="model[options.key]">';
+        beforeEach(() => {
+          manipulators = formlyConfig.templateManipulators[isPre ? 'preWrapper' : 'postWrapper'];
+          formlyConfig.setWrapper([
+            {
+              types: 'text',
+              template: '<div class="my-template-wrapper"><formly-transclude></formly-transclude></div>'
+            }
+          ]);
+          formlyConfig.setType({
+            name: 'text', template: textTemplate
+          });
+          scope.model = {};
+          scope.fields = [
+            {type: 'text'}
+          ];
+        });
+
+        var when = isPre ? 'before' : 'after';
+
+        it(`should call the manipulators when compiling a field ${when} the element is wrapped in wrappers`, () => {
+          var manipulatedTemplate;
+          manipulators.push((templateToManipulate, fieldOptions, scope) => {
+            if (isPre) {
+              expect(templateToManipulate).to.contain('text-template');
+            }
+            expect(fieldOptions).to.equal(scope.fields[0]);
+            expect(scope.options).to.equal(fieldOptions);
+            if (isPre) {
+              expect(templateToManipulate).to.not.contain('my-template-wrapper');
+            } else {
+              expect(templateToManipulate).to.contain('my-template-wrapper');
+            }
+            manipulatedTemplate = angular.element(templateToManipulate).addClass('manipulated');
+            return manipulatedTemplate;
+          });
+
+          manipulators.push((templateToManipulate, fieldOptions, scope) => {
+            if (isPre) {
+              expect(asHtml(manipulatedTemplate)).to.equal(templateToManipulate);
+            }
+            expect(fieldOptions).to.equal(scope.fields[0]);
+            expect(scope.options).to.equal(fieldOptions);
+            if (isPre) {
+              expect(templateToManipulate).to.not.contain('my-template-wrapper');
+            } else {
+              expect(templateToManipulate).to.contain('my-template-wrapper');
+            }
+            expect(templateToManipulate).to.contain('manipulated');
+            return angular.element(templateToManipulate).addClass('manipulated-twice');
+          });
+          var el = $compile(angular.element(template))(scope);
+          scope.$digest();
+          expect(el[0].querySelector('.manipulated')).to.exist;
+          expect(el[0].querySelector('.manipulated-twice')).to.exist;
+
+          function asHtml(el) {
+            return angular.element('<a></a>').append(el).html();
+          }
+        });
+      });
     }
   });
-};
+
+  describe('type controllers and link functions', () => {
+    let controllerFn, linkFn;
+    beforeEach(() => {
+      controllerFn = function($scope) {
+        $scope.setInTypeController = true;
+      };
+
+      linkFn = function(scope, el, attrs) {
+        scope.setInTypeLink = true;
+        scope.el = el;
+        scope.attrs = attrs;
+      };
+
+      formlyConfig.setType({
+        name: 'text',
+        template: `<input name="{{id}}" ng-model="model[options.key]" />`,
+        controller: ['$scope', controllerFn],
+        link: linkFn
+      });
+      scope.model = {};
+    });
+    it('should run the controller function of a type', () => {
+      scope.fields = [
+        {type: 'text'}
+      ];
+      const el = compileAndDigest();
+      var fieldEl = angular.element(el[0].querySelector('.formly-field'));
+      expect(fieldEl.isolateScope().setInTypeController).to.be.true;
+    });
+
+    it('should run the link function of a type', () => {
+      scope.fields = [
+        {type: 'text'}
+      ];
+      const el = compileAndDigest();
+      var fieldEl = angular.element(el[0].querySelector('.formly-field'));
+      var fieldScope = fieldEl.isolateScope();
+      expect(fieldScope.setInTypeLink).to.be.true;
+      expect(fieldScope.el[0]).to.equal(fieldEl[0]);
+    });
+
+    it('should run the controller of the specific field', () => {
+      scope.fields = [
+        {template: 'sweet mercy', controller: ['$scope', controllerFn]}
+      ];
+
+      const el = compileAndDigest();
+      var fieldEl = angular.element(el[0].querySelector('.formly-field'));
+      expect(fieldEl.isolateScope().setInTypeController).to.be.true;
+    });
+
+
+    it('should run the link function of a type', () => {
+      scope.fields = [
+        {template: 'sweet mercy', link: linkFn}
+      ];
+      const el = compileAndDigest();
+      var fieldEl = angular.element(el[0].querySelector('.formly-field'));
+      var fieldScope = fieldEl.isolateScope();
+      expect(fieldScope.setInTypeLink).to.be.true;
+      expect(fieldScope.el[0]).to.equal(fieldEl[0]);
+    });
+  });
+
+  describe(`type apiCheck`, () => {
+    let type = 'input';
+    beforeEach(() => {
+      formlyConfig.setType({
+        name: type,
+        template: '<label>{{to.label}}</label><input class="{{to.className}}" ng-model="model[options.key]" />',
+        apiCheck: {
+          templateOptions: apiCheck.shape({
+            label: apiCheck.string,
+            className: apiCheck.string
+          })
+        },
+        apiCheckInstance: apiCheck({
+          output: {prefix: 'custom-api-check'}
+        }),
+        apiCheckOptions: {
+          prefix: type + ' type checker',
+          url: 'http://example.com/some-custom-url'
+        }
+      });
+      scope.model = {};
+    });
+
+    it(`should not warn if everything's fine`, () => {
+      scope.fields = [
+        {type, templateOptions: {label: 'string', className: 'string'}}
+      ];
+      shouldNotWarn(compileAndDigest);
+    });
+
+    it(`should warn if everything's not fine`, () => {
+      scope.fields = [
+        {type, templateOptions: {label: 'string'}}
+      ];
+      shouldWarn(
+        /custom-api-check.*?input type checker.*?some-custom-url(.|\n)*?className/,
+        compileAndDigest
+      );
+    });
+
+    it(`should throw if the apiCheckFunction is set to "throw" and everything's not fine`, () => {
+      formlyConfig.getType(type).apiCheckFunction = 'throw';
+      scope.fields = [
+        {type, templateOptions: {label: 'string'}}
+      ];
+      expect(compileAndDigest).to.throw(
+        /custom-api-check.*?input type checker.*?some-custom-url(.|\n)*?className/
+      );
+    });
+  });
+
+  describe(`wrapper apiCheck`, () => {
+    const name = 'input';
+    const template = '<input ng-model="model[options.key]" />';
+    const wrapper = name;
+    beforeEach(() => {
+      formlyConfig.setWrapper({
+        name,
+        template:
+          '<div class="to.className"><label>{{to.label}}</label><formly-transclude></formly-transclude></div>',
+        apiCheck: {
+          templateOptions: apiCheck.shape({
+            label: apiCheck.string,
+            className: apiCheck.string
+          })
+        },
+        apiCheckInstance: apiCheck({
+          output: {prefix: 'custom-api-check'}
+        })
+      });
+      scope.model = {};
+    });
+
+    it(`should not warn if everything's fine`, () => {
+      scope.fields = [
+        {template, wrapper, templateOptions: {label: 'string', className: 'string'}}
+      ];
+      shouldNotWarn(compileAndDigest);
+    });
+
+    it(`should warn if everything's not fine`, () => {
+      scope.fields = [
+        {template, wrapper, templateOptions: {label: 'string'}}
+      ];
+      shouldWarn(/custom-api-check.*?formly-field(.|\n)*?className/, compileAndDigest);
+    });
+
+    it(`should throw if the apiCheckFunction is set to "throw" and everything's not fine`, () => {
+      formlyConfig.getWrapper(name).apiCheckFunction = 'throw';
+      scope.fields = [
+        {template, wrapper, templateOptions: {label: 'string'}}
+      ];
+      expect(compileAndDigest).to.throw(/custom-api-check.*?formly-field(.|\n)*?className/);
+    });
+  });
+
+  function compileAndDigest() {
+    const el = $compile(template)(scope);
+    scope.$digest();
+    return el;
+  }
+
+  function shouldWarn(match, test) {
+    var originalWarn = console.warn;
+    var calledArgs;
+    console.warn = function() {
+      calledArgs = arguments;
+    };
+    test();
+    expect(calledArgs[0]).to.match(match);
+    console.warn = originalWarn;
+  }
+
+  function shouldNotWarn(test) {
+    var originalWarn = console.warn;
+    var callCount = 0;
+    console.warn = () => callCount++;
+    test();
+    expect(callCount).to.equal(0);
+    console.warn = originalWarn;
+  }
+});

--- a/src/directives/formly-focus.js
+++ b/src/directives/formly-focus.js
@@ -1,28 +1,26 @@
-module.exports = ngModule => {
-  ngModule.directive('formlyFocus', function($timeout, $document) {
-    /* jshint -W052 */
-    return {
-      restrict: 'A',
-      link: function(scope, element, attrs) {
-        var previousEl = null;
-        var el = element[0];
-        var doc = $document[0];
-        attrs.$observe('formlyFocus', function(value) {
-          if (value === 'true') {
-            $timeout(function() {
-              previousEl = doc.activeElement;
-              el.focus();
-            }, ~~attrs.focusWait);
-          } else if (value === 'false') {
-            if (doc.activeElement === el) {
-              el.blur();
-              if (attrs.hasOwnProperty('refocus') && previousEl) {
-                previousEl.focus();
-              }
+export default function formlyFocus ($timeout, $document) {
+  /* jshint -W052 */
+  return {
+    restrict: 'A',
+    link: function(scope, element, attrs) {
+      var previousEl = null;
+      var el = element[0];
+      var doc = $document[0];
+      attrs.$observe('formlyFocus', function(value) {
+        if (value === 'true') {
+          $timeout(function() {
+            previousEl = doc.activeElement;
+            el.focus();
+          }, ~~attrs.focusWait);
+        } else if (value === 'false') {
+          if (doc.activeElement === el) {
+            el.blur();
+            if (attrs.hasOwnProperty('refocus') && previousEl) {
+              previousEl.focus();
             }
           }
-        });
-      }
-    };
-  });
-};
+        }
+      });
+    }
+  };
+}

--- a/src/directives/formly-form.js
+++ b/src/directives/formly-form.js
@@ -1,175 +1,171 @@
-let angular = require('angular-fix');
+import angular from 'angular-fix';
 
-module.exports = ngModule => {
-  ngModule.directive('formlyForm', formlyForm);
+/**
+ * @ngdoc directive
+ * @name formlyForm
+ * @restrict E
+ */
+function formlyForm(formlyUsability, $parse, formlyApiCheck, formlyConfig) {
+  var currentFormId = 1;
+  var optionsApi = [
+    formlyApiCheck.shape({
+      formState: formlyApiCheck.object.optional,
+      resetModel: formlyApiCheck.func.optional,
+      updateInitialValue: formlyApiCheck.func.optional,
+      removeChromeAutoComplete: formlyApiCheck.bool.optional
+    }).strict.optional
+  ];
+  return {
+    restrict: 'E',
+    template: function(el, attrs) {
+      /* jshint -W033 */ // this because jshint is broken I guess...
+      const rootEl = attrs.rootEl || 'ng-form';
+      const formName = `formly_${currentFormId++}`;
+      return `
+        <${rootEl} class="formly"
+                 name="${formName}"
+                 role="form">
+          <div formly-field
+               ng-repeat="field in fields track by $index"
+               ng-if="!field.hide"
+               class="formly-field {{field.type ? 'formly-field-' + field.type : ''}}"
+               options="field"
+               model="field.model || model"
+               fields="fields"
+               form="${formName}"
+               form-id="${formName}"
+               form-state="options.formState"
+               index="$index">
+          </div>
+          <div ng-transclude></div>
+        </${rootEl}>
+      `;
+    },
+    replace: true,
+    transclude: true,
+    scope: {
+      fields: '=',
+      model: '=',
+      form: '=?',
+      options: '=?'
+    },
+    controller: function($scope) {
+      setupOptions();
+      $scope.model = $scope.model || {};
+      $scope.fields = $scope.fields || [];
 
-  formlyForm.tests = ON_TEST ? require('./formly-form.test')(ngModule) : null;
+      angular.forEach($scope.fields, attachKey); // attaches a key based on the index if a key isn't specified
+      angular.forEach($scope.fields, setupWatchers); // setup watchers for all fields
 
-  /**
-   * @ngdoc directive
-   * @name formlyForm
-   * @restrict E
-   */
-  function formlyForm(formlyUsability, $parse, formlyApiCheck, formlyConfig) {
-    var currentFormId = 1;
-    var optionsApi = [
-      formlyApiCheck.shape({
-        formState: formlyApiCheck.object.optional,
-        resetModel: formlyApiCheck.func.optional,
-        updateInitialValue: formlyApiCheck.func.optional,
-        removeChromeAutoComplete: formlyApiCheck.bool.optional
-      }).strict.optional
-    ];
-    return {
-      restrict: 'E',
-      template: function(el, attrs) {
-        /* jshint -W033 */ // this because jshint is broken I guess...
-        const rootEl = attrs.rootEl || 'ng-form';
-        const formName = `formly_${currentFormId++}`;
-        return `
-          <${rootEl} class="formly"
-                   name="${formName}"
-                   role="form">
-            <div formly-field
-                 ng-repeat="field in fields track by $index"
-                 ng-if="!field.hide"
-                 class="formly-field {{field.type ? 'formly-field-' + field.type : ''}}"
-                 options="field"
-                 model="field.model || model"
-                 fields="fields"
-                 form="${formName}"
-                 form-id="${formName}"
-                 form-state="options.formState"
-                 index="$index">
-            </div>
-            <div ng-transclude></div>
-          </${rootEl}>
-        `;
-      },
-      replace: true,
-      transclude: true,
-      scope: {
-        fields: '=',
-        model: '=',
-        form: '=?',
-        options: '=?'
-      },
-      controller: function($scope) {
-        setupOptions();
-        $scope.model = $scope.model || {};
-        $scope.fields = $scope.fields || [];
+      // watch the model and evaluate watch expressions that depend on it.
+      $scope.$watch('model', function onResultUpdate(newResult) {
+        angular.forEach($scope.fields, function(field) {
+          /*jshint -W030 */
+          field.runExpressions && field.runExpressions(newResult);
+        });
+      }, true);
 
-        angular.forEach($scope.fields, attachKey); // attaches a key based on the index if a key isn't specified
-        angular.forEach($scope.fields, setupWatchers); // setup watchers for all fields
+      function setupOptions() {
+        formlyApiCheck.throw(optionsApi, [$scope.options], {prefix: 'formly-form options check'});
+        $scope.options = $scope.options || {};
+        $scope.options.formState = $scope.options.formState || {};
 
-        // watch the model and evaluate watch expressions that depend on it.
-        $scope.$watch('model', function onResultUpdate(newResult) {
-          angular.forEach($scope.fields, function(field) {
-            /*jshint -W030 */
-            field.runExpressions && field.runExpressions(newResult);
-          });
-        }, true);
+        angular.extend($scope.options, {
+          updateInitialValue,
+          resetModel
+        });
 
-        function setupOptions() {
-          formlyApiCheck.throw(optionsApi, [$scope.options], {prefix: 'formly-form options check'});
-          $scope.options = $scope.options || {};
-          $scope.options.formState = $scope.options.formState || {};
-
-          angular.extend($scope.options, {
-            updateInitialValue,
-            resetModel
-          });
-
-        }
-
-        function updateInitialValue() {
-          angular.forEach($scope.fields, field => field.updateInitialValue());
-        }
-
-        function resetModel() {
-          angular.forEach($scope.fields, field => field.resetModel());
-        }
-
-        function attachKey(field, index) {
-          field.key = field.key || index || 0;
-        }
-
-        function setupWatchers(field, index) {
-          if (!angular.isDefined(field.watcher)) {
-            return;
-          }
-          var watchers = field.watcher;
-          if (!angular.isArray(watchers)) {
-            watchers = [watchers];
-          }
-          angular.forEach(watchers, function(watcher) {
-            if (!angular.isDefined(watcher.listener)) {
-              throw formlyUsability.getFieldError(
-                'all-field-watchers-must-have-a-listener',
-                'All field watchers must have a listener', field
-              );
-            }
-            var watchExpression = getWatchExpression(watcher, field, index);
-            var watchListener = getWatchListener(watcher, field, index);
-
-            var type = watcher.type || '$watch';
-            watcher.stopWatching = $scope[type](watchExpression, watchListener, watcher.watchDeep);
-          });
-        }
-
-        function getWatchExpression(watcher, field, index) {
-          var watchExpression = watcher.expression || `model['${field.key}']`;
-          if (angular.isFunction(watchExpression)) {
-            // wrap the field's watch expression so we can call it with the field as the first arg
-            // and the stop function as the last arg as a helper
-            var originalExpression = watchExpression;
-            watchExpression = function formlyWatchExpression() {
-              var args = modifyArgs(watcher, index, ...arguments);
-              return originalExpression(...args);
-            };
-            watchExpression.displayName = `Formly Watch Expression for field for ${field.key}`;
-          }
-          return watchExpression;
-        }
-
-        function getWatchListener(watcher, field, index) {
-          var watchListener = watcher.listener;
-          if (angular.isFunction(watchListener)) {
-            // wrap the field's watch listener so we can call it with the field as the first arg
-            // and the stop function as the last arg as a helper
-            var originalListener = watchListener;
-            watchListener = function formlyWatchListener() {
-              var args = modifyArgs(watcher, index, ...arguments);
-              return originalListener(...args);
-            };
-            watchListener.displayName = `Formly Watch Listener for field for ${field.key}`;
-          }
-          return watchListener;
-        }
-
-        function modifyArgs(watcher, index, ...originalArgs) {
-          return [$scope.fields[index], ...originalArgs, watcher.stopWatching];
-        }
-      },
-      link(scope, el, attrs) {
-        if (attrs.form) {
-          const formId = attrs.name;
-          $parse(attrs.form).assign(scope.$parent, scope[formId]);
-        }
-
-        // chrome autocomplete lameness
-        // see https://code.google.com/p/chromium/issues/detail?id=468153#c14
-        // ლ(ಠ益ಠლ)   (╯°□°)╯︵ ┻━┻    (◞‸◟；)
-        const global = formlyConfig.extras.removeChromeAutoComplete === true;
-        const offInstance = scope.options && scope.options.removeChromeAutoComplete === false;
-        const onInstance = scope.options && scope.options.removeChromeAutoComplete === true;
-        if ((global && !offInstance) || onInstance) {
-          const input = document.createElement('input');
-          input.setAttribute('autocomplete', 'address-level4');
-          input.setAttribute('hidden', true);
-          el[0].appendChild(input);
-        }
       }
-    };
-  }
-};
+
+      function updateInitialValue() {
+        angular.forEach($scope.fields, field => field.updateInitialValue());
+      }
+
+      function resetModel() {
+        angular.forEach($scope.fields, field => field.resetModel());
+      }
+
+      function attachKey(field, index) {
+        field.key = field.key || index || 0;
+      }
+
+      function setupWatchers(field, index) {
+        if (!angular.isDefined(field.watcher)) {
+          return;
+        }
+        var watchers = field.watcher;
+        if (!angular.isArray(watchers)) {
+          watchers = [watchers];
+        }
+        angular.forEach(watchers, function(watcher) {
+          if (!angular.isDefined(watcher.listener)) {
+            throw formlyUsability.getFieldError(
+              'all-field-watchers-must-have-a-listener',
+              'All field watchers must have a listener', field
+            );
+          }
+          var watchExpression = getWatchExpression(watcher, field, index);
+          var watchListener = getWatchListener(watcher, field, index);
+
+          var type = watcher.type || '$watch';
+          watcher.stopWatching = $scope[type](watchExpression, watchListener, watcher.watchDeep);
+        });
+      }
+
+      function getWatchExpression(watcher, field, index) {
+        var watchExpression = watcher.expression || `model['${field.key}']`;
+        if (angular.isFunction(watchExpression)) {
+          // wrap the field's watch expression so we can call it with the field as the first arg
+          // and the stop function as the last arg as a helper
+          var originalExpression = watchExpression;
+          watchExpression = function formlyWatchExpression() {
+            var args = modifyArgs(watcher, index, ...arguments);
+            return originalExpression(...args);
+          };
+          watchExpression.displayName = `Formly Watch Expression for field for ${field.key}`;
+        }
+        return watchExpression;
+      }
+
+      function getWatchListener(watcher, field, index) {
+        var watchListener = watcher.listener;
+        if (angular.isFunction(watchListener)) {
+          // wrap the field's watch listener so we can call it with the field as the first arg
+          // and the stop function as the last arg as a helper
+          var originalListener = watchListener;
+          watchListener = function formlyWatchListener() {
+            var args = modifyArgs(watcher, index, ...arguments);
+            return originalListener(...args);
+          };
+          watchListener.displayName = `Formly Watch Listener for field for ${field.key}`;
+        }
+        return watchListener;
+      }
+
+      function modifyArgs(watcher, index, ...originalArgs) {
+        return [$scope.fields[index], ...originalArgs, watcher.stopWatching];
+      }
+    },
+    link(scope, el, attrs) {
+      if (attrs.form) {
+        const formId = attrs.name;
+        $parse(attrs.form).assign(scope.$parent, scope[formId]);
+      }
+
+      // chrome autocomplete lameness
+      // see https://code.google.com/p/chromium/issues/detail?id=468153#c14
+      // ლ(ಠ益ಠლ)   (╯°□°)╯︵ ┻━┻    (◞‸◟；)
+      const global = formlyConfig.extras.removeChromeAutoComplete === true;
+      const offInstance = scope.options && scope.options.removeChromeAutoComplete === false;
+      const onInstance = scope.options && scope.options.removeChromeAutoComplete === true;
+      if ((global && !offInstance) || onInstance) {
+        const input = document.createElement('input');
+        input.setAttribute('autocomplete', 'address-level4');
+        input.setAttribute('hidden', true);
+        el[0].appendChild(input);
+      }
+    }
+  };
+}
+
+export default formlyForm;

--- a/src/directives/formly-form.js
+++ b/src/directives/formly-form.js
@@ -5,7 +5,7 @@ import angular from 'angular-fix';
  * @name formlyForm
  * @restrict E
  */
-function formlyForm(formlyUsability, $parse, formlyApiCheck, formlyConfig) {
+export default function formlyForm(formlyUsability, $parse, formlyApiCheck, formlyConfig) {
   var currentFormId = 1;
   var optionsApi = [
     formlyApiCheck.shape({
@@ -167,5 +167,3 @@ function formlyForm(formlyUsability, $parse, formlyApiCheck, formlyConfig) {
     }
   };
 }
-
-export default formlyForm;

--- a/src/directives/formly-form.test.js
+++ b/src/directives/formly-form.test.js
@@ -1,234 +1,232 @@
-module.exports = ngModule => {
-  describe('formly-form', () => {
-    const input = '<input ng-model="model[options.key]" />';
-    let $compile, scope;
+describe('formly-form', () => {
+  const input = '<input ng-model="model[options.key]" />';
+  let $compile, scope;
 
-    beforeEach(window.module(ngModule.name));
-    beforeEach(inject((_$compile_, $rootScope) => {
-      $compile = _$compile_;
-      scope = $rootScope.$new();
-    }));
+  beforeEach(window.module('formly'));
+  beforeEach(inject((_$compile_, $rootScope) => {
+    $compile = _$compile_;
+    scope = $rootScope.$new();
+  }));
 
-    it('should use ng-form as the default root tag', () => {
-      const el = compileAndDigest(`
-        <formly-form model="model" fields="fields" form="theForm"></formly-form>
-      `);
-      expect(el.length).to.equal(1);
-      expect(el.prop('nodeName').toLowerCase()).to.equal('ng-form');
-    });
-
-    it('should use a different root tag when specified', () => {
-      const el = compileAndDigest(`
-        <formly-form model="model" fields="fields" form="theForm" root-el="form"></formly-form>
-      `);
-      expect(el.length).to.equal(1);
-      expect(el.prop('nodeName').toLowerCase()).to.equal('form');
-    });
-
-    it(`should not allow sibling forms to override each other on a parent form`, () => {
-      compileAndDigest(`
-        <form name="parent">
-          <formly-form form="form1" model="model" fields="fields"></formly-form>
-          <formly-form form="form2" model="model" fields="fields"></formly-form>
-        </form>
-      `);
-      expect(scope.parent).to.have.property('formly_1');
-      expect(scope.parent).to.have.property('formly_2');
-    });
-
-    it(`should place the form control on the scope property defined by the form attribute`, () => {
-      compileAndDigest(`
-        <formly-form form="vm.myForm" model="model" fields="fields"></formly-form>
-      `);
-      expect(scope.vm).to.have.property('myForm');
-      expect(scope.vm.myForm).to.have.property('$name');
-    });
-
-
-    it(`should not require a form attribute`, () => {
-      expect(() => {
-        compileAndDigest(`
-          <formly-form model="model" fields="fields"></formly-form>
-        `);
-      }).to.not.throw();
-    });
-
-    it(`should require the model attribute`, () => {
-      expect(() => {
-        compileAndDigest(`
-          <formly-form fields="fields"></formly-form>
-        `);
-      }).to.throw();
-    });
-
-    it(`should require the fields attribute`, () => {
-      expect(() => {
-        compileAndDigest(`
-          <formly-form model="model"></formly-form>
-        `);
-      }).to.throw();
-    });
-
-    it(`should initialize the model and the fields if not provided`, () => {
-      compileAndDigest(`
-        <formly-form model="model" fields="fields"></formly-form>
-      `);
-      expect(scope.model).to.exist;
-      expect(scope.fields).to.exist;
-    });
-
-    it(`should initialize the model and fields if they are null`, () => {
-      scope.model = null;
-      scope.fields = null;
-      compileAndDigest(`
-        <formly-form model="model" fields="fields"></formly-form>
-      `);
-      expect(scope.model).to.exist;
-      expect(scope.fields).to.exist;
-    });
-
-    describe(`options`, () => {
-      const template = '<formly-form options="options" model="model" fields="fields"></formly-form>';
-      beforeEach(() => {
-        scope.model = {
-          foo: 'myFoo',
-          bar: 123,
-          foobar: 'ab@cd.com'
-        };
-
-        scope.fields = [
-          {template: input, key: 'foo'},
-          {template: input, key: 'bar', templateOptions: {type: 'numaber'}},
-          {template: input, key: 'foobar', templateOptions: {type: 'email'}}
-        ];
-        scope.options = {};
-      });
-
-      it(`should throw an error with extra options`, () => {
-        expect(() => {
-          scope.options = {extra: true};
-          compileAndDigest(`
-            <formly-form model="model" fields="fields" options="options"></formly-form>
-          `);
-        }).to.throw();
-      });
-
-      describe(`resetModel`, () => {
-        it(`should reset the model that's given`, () => {
-          compileAndDigest(template);
-          expect(typeof scope.options.resetModel).to.eq('function');
-          const previousFoo = scope.model.foo;
-          scope.model.foo = 'newFoo';
-          scope.options.resetModel();
-          expect(scope.model.foo).to.eq(previousFoo);
-        });
-
-        it(`should reset the $viewValue of fields`, () => {
-          compileAndDigest(template);
-          const previousFoobar = scope.model.foobar;
-          scope.fields[2].formControl.$setViewValue('not-an-email');
-          scope.options.resetModel();
-          expect(scope.fields[2].formControl.$viewValue).to.equal(previousFoobar);
-        });
-
-        it(`should reset the $viewValue and $modelValue to undefined if the value was not originally defined`, () => {
-          scope.fields.push({
-            template: input, key: 'baz', templateOptions: {required: true}
-          });
-          compileAndDigest(template);
-          const fc = scope.fields[scope.fields.length - 1].formControl;
-          scope.model.baz = 'hello world';
-          scope.$digest();
-          expect(fc.$viewValue).to.eq('hello world');
-          expect(fc.$modelValue).to.eq('hello world');
-          scope.options.resetModel();
-          expect(scope.model.baz).to.be.undefined;
-          expect(fc.$viewValue).to.be.undefined;
-          expect(fc.$modelValue).to.be.undefined;
-        });
-
-        it(`should rerender the ng-model element`, () => {
-          const el = compileAndDigest(template);
-          const ngModelNode = el[0].querySelector('[ng-model]');
-          scope.model.foo = 'hey there!';
-          scope.$digest();
-          scope.options.resetModel();
-          expect(ngModelNode.value).to.eq('myFoo');
-        });
-
-        it(`should reset models of fields`, () => {
-          scope.fieldModel = {baz: false};
-          scope.fields.push({
-            template: input, key: 'baz', model: scope.fieldModel
-          });
-
-          compileAndDigest(template);
-
-          scope.fieldModel.baz = true;
-          scope.options.resetModel();
-          expect(scope.fieldModel.baz).to.be.false;
-        });
-      });
-
-      describe(`updateInitialValue`, () => {
-
-        it(`should update the initial value of the fields`, () => {
-          compileAndDigest(template);
-          const field = scope.fields[0];
-          expect(field.initialValue).to.equal('myFoo');
-          scope.model.foo = 'otherValue';
-          scope.options.updateInitialValue();
-          expect(field.initialValue).to.equal('otherValue');
-        });
-
-        it(`should reset to the updated initial value`, () => {
-          compileAndDigest(template);
-          const field = scope.fields[0];
-          scope.model.foo = 'otherValue';
-          scope.options.updateInitialValue();
-          scope.model.foo = 'otherValueAgain';
-          scope.options.resetModel();
-          expect(field.initialValue).to.equal('otherValue');
-          expect(scope.model.foo).to.equal('otherValue');
-        });
-      });
-
-      describe(`removeChromeAutoComplete`, () => {
-        it(`should not have a hidden input when nothing is specified`, () => {
-          const el = compileAndDigest(template);
-          const autoCompleteFixEl = el[0].querySelector('[autocomplete="address-level4"]');
-          expect(autoCompleteFixEl).to.be.null;
-        });
-
-        it(`should add a hidden input when specified as true`, () => {
-          scope.options.removeChromeAutoComplete = true;
-          const el = compileAndDigest(template);
-          const autoCompleteFixEl = el[0].querySelector('[autocomplete="address-level4"]');
-          expect(autoCompleteFixEl).to.exist;
-        });
-
-        it(`should override the 'true' global configuration`, inject((formlyConfig) => {
-          formlyConfig.extras.removeChromeAutoComplete = true;
-          scope.options.removeChromeAutoComplete = false;
-          const el = compileAndDigest(template);
-          const autoCompleteFixEl = el[0].querySelector('[autocomplete="address-level4"]');
-          expect(autoCompleteFixEl).to.be.null;
-        }));
-
-        it(`should be added regardless of the option if the global config is set`, inject((formlyConfig) => {
-          formlyConfig.extras.removeChromeAutoComplete = true;
-          const el = compileAndDigest(template);
-          const autoCompleteFixEl = el[0].querySelector('[autocomplete="address-level4"]');
-          expect(autoCompleteFixEl).to.exist;
-        }));
-      });
-    });
-
-    function compileAndDigest(template) {
-      const el = $compile(template)(scope);
-      scope.$digest();
-      return el;
-    }
-
+  it('should use ng-form as the default root tag', () => {
+    const el = compileAndDigest(`
+      <formly-form model="model" fields="fields" form="theForm"></formly-form>
+    `);
+    expect(el.length).to.equal(1);
+    expect(el.prop('nodeName').toLowerCase()).to.equal('ng-form');
   });
-};
+
+  it('should use a different root tag when specified', () => {
+    const el = compileAndDigest(`
+      <formly-form model="model" fields="fields" form="theForm" root-el="form"></formly-form>
+    `);
+    expect(el.length).to.equal(1);
+    expect(el.prop('nodeName').toLowerCase()).to.equal('form');
+  });
+
+  it(`should not allow sibling forms to override each other on a parent form`, () => {
+    compileAndDigest(`
+      <form name="parent">
+        <formly-form form="form1" model="model" fields="fields"></formly-form>
+        <formly-form form="form2" model="model" fields="fields"></formly-form>
+      </form>
+    `);
+    expect(scope.parent).to.have.property('formly_1');
+    expect(scope.parent).to.have.property('formly_2');
+  });
+
+  it(`should place the form control on the scope property defined by the form attribute`, () => {
+    compileAndDigest(`
+      <formly-form form="vm.myForm" model="model" fields="fields"></formly-form>
+    `);
+    expect(scope.vm).to.have.property('myForm');
+    expect(scope.vm.myForm).to.have.property('$name');
+  });
+
+
+  it(`should not require a form attribute`, () => {
+    expect(() => {
+      compileAndDigest(`
+        <formly-form model="model" fields="fields"></formly-form>
+      `);
+    }).to.not.throw();
+  });
+
+  it(`should require the model attribute`, () => {
+    expect(() => {
+      compileAndDigest(`
+        <formly-form fields="fields"></formly-form>
+      `);
+    }).to.throw();
+  });
+
+  it(`should require the fields attribute`, () => {
+    expect(() => {
+      compileAndDigest(`
+        <formly-form model="model"></formly-form>
+      `);
+    }).to.throw();
+  });
+
+  it(`should initialize the model and the fields if not provided`, () => {
+    compileAndDigest(`
+      <formly-form model="model" fields="fields"></formly-form>
+    `);
+    expect(scope.model).to.exist;
+    expect(scope.fields).to.exist;
+  });
+
+  it(`should initialize the model and fields if they are null`, () => {
+    scope.model = null;
+    scope.fields = null;
+    compileAndDigest(`
+      <formly-form model="model" fields="fields"></formly-form>
+    `);
+    expect(scope.model).to.exist;
+    expect(scope.fields).to.exist;
+  });
+
+  describe(`options`, () => {
+    const template = '<formly-form options="options" model="model" fields="fields"></formly-form>';
+    beforeEach(() => {
+      scope.model = {
+        foo: 'myFoo',
+        bar: 123,
+        foobar: 'ab@cd.com'
+      };
+
+      scope.fields = [
+        {template: input, key: 'foo'},
+        {template: input, key: 'bar', templateOptions: {type: 'numaber'}},
+        {template: input, key: 'foobar', templateOptions: {type: 'email'}}
+      ];
+      scope.options = {};
+    });
+
+    it(`should throw an error with extra options`, () => {
+      expect(() => {
+        scope.options = {extra: true};
+        compileAndDigest(`
+          <formly-form model="model" fields="fields" options="options"></formly-form>
+        `);
+      }).to.throw();
+    });
+
+    describe(`resetModel`, () => {
+      it(`should reset the model that's given`, () => {
+        compileAndDigest(template);
+        expect(typeof scope.options.resetModel).to.eq('function');
+        const previousFoo = scope.model.foo;
+        scope.model.foo = 'newFoo';
+        scope.options.resetModel();
+        expect(scope.model.foo).to.eq(previousFoo);
+      });
+
+      it(`should reset the $viewValue of fields`, () => {
+        compileAndDigest(template);
+        const previousFoobar = scope.model.foobar;
+        scope.fields[2].formControl.$setViewValue('not-an-email');
+        scope.options.resetModel();
+        expect(scope.fields[2].formControl.$viewValue).to.equal(previousFoobar);
+      });
+
+      it(`should reset the $viewValue and $modelValue to undefined if the value was not originally defined`, () => {
+        scope.fields.push({
+          template: input, key: 'baz', templateOptions: {required: true}
+        });
+        compileAndDigest(template);
+        const fc = scope.fields[scope.fields.length - 1].formControl;
+        scope.model.baz = 'hello world';
+        scope.$digest();
+        expect(fc.$viewValue).to.eq('hello world');
+        expect(fc.$modelValue).to.eq('hello world');
+        scope.options.resetModel();
+        expect(scope.model.baz).to.be.undefined;
+        expect(fc.$viewValue).to.be.undefined;
+        expect(fc.$modelValue).to.be.undefined;
+      });
+
+      it(`should rerender the ng-model element`, () => {
+        const el = compileAndDigest(template);
+        const ngModelNode = el[0].querySelector('[ng-model]');
+        scope.model.foo = 'hey there!';
+        scope.$digest();
+        scope.options.resetModel();
+        expect(ngModelNode.value).to.eq('myFoo');
+      });
+
+      it(`should reset models of fields`, () => {
+        scope.fieldModel = {baz: false};
+        scope.fields.push({
+          template: input, key: 'baz', model: scope.fieldModel
+        });
+
+        compileAndDigest(template);
+
+        scope.fieldModel.baz = true;
+        scope.options.resetModel();
+        expect(scope.fieldModel.baz).to.be.false;
+      });
+    });
+
+    describe(`updateInitialValue`, () => {
+
+      it(`should update the initial value of the fields`, () => {
+        compileAndDigest(template);
+        const field = scope.fields[0];
+        expect(field.initialValue).to.equal('myFoo');
+        scope.model.foo = 'otherValue';
+        scope.options.updateInitialValue();
+        expect(field.initialValue).to.equal('otherValue');
+      });
+
+      it(`should reset to the updated initial value`, () => {
+        compileAndDigest(template);
+        const field = scope.fields[0];
+        scope.model.foo = 'otherValue';
+        scope.options.updateInitialValue();
+        scope.model.foo = 'otherValueAgain';
+        scope.options.resetModel();
+        expect(field.initialValue).to.equal('otherValue');
+        expect(scope.model.foo).to.equal('otherValue');
+      });
+    });
+
+    describe(`removeChromeAutoComplete`, () => {
+      it(`should not have a hidden input when nothing is specified`, () => {
+        const el = compileAndDigest(template);
+        const autoCompleteFixEl = el[0].querySelector('[autocomplete="address-level4"]');
+        expect(autoCompleteFixEl).to.be.null;
+      });
+
+      it(`should add a hidden input when specified as true`, () => {
+        scope.options.removeChromeAutoComplete = true;
+        const el = compileAndDigest(template);
+        const autoCompleteFixEl = el[0].querySelector('[autocomplete="address-level4"]');
+        expect(autoCompleteFixEl).to.exist;
+      });
+
+      it(`should override the 'true' global configuration`, inject((formlyConfig) => {
+        formlyConfig.extras.removeChromeAutoComplete = true;
+        scope.options.removeChromeAutoComplete = false;
+        const el = compileAndDigest(template);
+        const autoCompleteFixEl = el[0].querySelector('[autocomplete="address-level4"]');
+        expect(autoCompleteFixEl).to.be.null;
+      }));
+
+      it(`should be added regardless of the option if the global config is set`, inject((formlyConfig) => {
+        formlyConfig.extras.removeChromeAutoComplete = true;
+        const el = compileAndDigest(template);
+        const autoCompleteFixEl = el[0].querySelector('[autocomplete="address-level4"]');
+        expect(autoCompleteFixEl).to.exist;
+      }));
+    });
+  });
+
+  function compileAndDigest(template) {
+    const el = $compile(template)(scope);
+    scope.$digest();
+    return el;
+  }
+
+});

--- a/src/directives/formly-form.test.js
+++ b/src/directives/formly-form.test.js
@@ -1,3 +1,5 @@
+import {expect} from 'chai';
+
 describe('formly-form', () => {
   const input = '<input ng-model="model[options.key]" />';
   let $compile, scope;

--- a/src/directives/index.js
+++ b/src/directives/index.js
@@ -1,6 +1,0 @@
-module.exports = ngModule => {
-  require('./formly-custom-validation')(ngModule);
-  require('./formly-field')(ngModule);
-  require('./formly-form')(ngModule);
-  require('./formly-focus')(ngModule);
-};

--- a/src/index.common.js
+++ b/src/index.common.js
@@ -1,31 +1,43 @@
-const apiCheck = require('api-check');
-if (!apiCheck) {
-  throw new Error(
-    'angular-formly requires the library apiCheck.js! Please include it! ' +
-      require('./other/docsBaseUrl') + 'apicheckjs-dependency-required'
-  );
-}
+import angular from 'angular-fix';
+
+import formlyApiCheck from './providers/formlyApiCheck';
+import formlyErrorAndWarningsUrlPrefix from './providers/formlyErrorAndWarningsUrlPrefix';
+import formlyVersion from './providers/formlyVersion';
+import formlyUsability from './providers/formlyUsability';
+import formlyConfig from './providers/formlyConfig';
+import formlyValidationMessages from './providers/formlyValidationMessages';
+import formlyUtil from './services/formlyUtil';
+import formlyWarn from './services/formlyWarn';
+
+import formlyCustomValidation from './directives/formly-custom-validation';
+import formlyField from './directives/formly-field';
+import formlyFocus from './directives/formly-focus';
+import formlyForm from './directives/formly-form';
+
+import formlyNgModelAttrsManipulator from './run/formlyNgModelAttrsManipulator';
+import formlyCustomTags from './run/formlyCustomTags';
+
 const ngModuleName = 'formly';
-const angular = require('./angular-fix');
+
+export default ngModuleName;
+
 const ngModule = angular.module(ngModuleName, []);
 
-ngModule.constant('formlyApiCheck', require('./providers/formlyApiCheck'));
-ngModule.constant('formlyErrorAndWarningsUrlPrefix', require('./providers/formlyErrorAndWarningsUrlPrefix'));
-ngModule.constant('formlyVersion', require('./providers/formlyVersion'));
+ngModule.constant('formlyApiCheck', formlyApiCheck);
+ngModule.constant('formlyErrorAndWarningsUrlPrefix', formlyErrorAndWarningsUrlPrefix);
+ngModule.constant('formlyVersion', formlyVersion);
 
-ngModule.provider('formlyUsability', require('./providers/formlyUsability'));
-ngModule.provider('formlyConfig', require('./providers/formlyConfig'));
+ngModule.provider('formlyUsability', formlyUsability);
+ngModule.provider('formlyConfig', formlyConfig);
 
-ngModule.factory('formlyValidationMessages', require('./providers/formlyValidationMessages'));
-ngModule.factory('formlyUtil', require('./services/formlyUtil'));
-ngModule.factory('formlyWarn', require('./services/formlyWarn'));
+ngModule.factory('formlyValidationMessages', formlyValidationMessages);
+ngModule.factory('formlyUtil', formlyUtil);
+ngModule.factory('formlyWarn', formlyWarn);
 
-ngModule.directive('formlyCustomValidation', require('./directives/formly-custom-validation'));
-ngModule.directive('formlyField', require('./directives/formly-field'));
-ngModule.directive('formlyFocus', require('./directives/formly-focus'));
-ngModule.directive('formlyForm', require('./directives/formly-form'));
+ngModule.directive('formlyCustomValidation', formlyCustomValidation);
+ngModule.directive('formlyField', formlyField);
+ngModule.directive('formlyFocus', formlyFocus);
+ngModule.directive('formlyForm', formlyForm);
 
-ngModule.run(require('./run/formlyNgModelAttrsManipulator'));
-ngModule.run(require('./run/formlyCustomTags'));
-
-module.exports = ngModuleName;
+ngModule.run(formlyNgModelAttrsManipulator);
+ngModule.run(formlyCustomTags);

--- a/src/index.common.js
+++ b/src/index.common.js
@@ -9,9 +9,23 @@ const ngModuleName = 'formly';
 const angular = require('./angular-fix');
 const ngModule = angular.module(ngModuleName, []);
 
-require('./providers')(ngModule);
-require('./services')(ngModule);
-require('./directives')(ngModule);
-require('./run')(ngModule);
+ngModule.constant('formlyApiCheck', require('./providers/formlyApiCheck'));
+ngModule.constant('formlyErrorAndWarningsUrlPrefix', require('./providers/formlyErrorAndWarningsUrlPrefix'));
+ngModule.constant('formlyVersion', require('./providers/formlyVersion'));
+
+ngModule.provider('formlyUsability', require('./providers/formlyUsability'));
+ngModule.provider('formlyConfig', require('./providers/formlyConfig'));
+
+ngModule.factory('formlyValidationMessages', require('./providers/formlyValidationMessages'));
+ngModule.factory('formlyUtil', require('./services/formlyUtil'));
+ngModule.factory('formlyWarn', require('./services/formlyWarn'));
+
+ngModule.directive('formlyCustomValidation', require('./directives/formly-custom-validation'));
+ngModule.directive('formlyField', require('./directives/formly-field'));
+ngModule.directive('formlyFocus', require('./directives/formly-focus'));
+ngModule.directive('formlyForm', require('./directives/formly-form'));
+
+ngModule.run(require('./run/formlyNgModelAttrsManipulator'));
+ngModule.run(require('./run/formlyCustomTags'));
 
 module.exports = ngModuleName;

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
-module.exports = require('./index.common');
+import index from './index.common';
+export default index;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,8 +1,17 @@
-require('./angular-fix');
+let angular = require('./angular-fix');
 require('angular-mocks/angular-mocks');
 window.apiCheck = require('api-check');
 const chai = require('chai');
 const sinonChai = require('sinon-chai');
 window.expect = chai.expect;
 chai.use(sinonChai);
+
+require('./providers/formlyApiCheck.test');
+require('./providers/formlyConfig.test');
+require('./services/formlyUtil.test');
+require('./directives/formly-custom-validation.test');
+require('./directives/formly-field.test');
+require('./directives/formly-form.test');
+require('./run/formlyNgModelAttrsManipulator.test');
+
 module.exports = require('./index.common');

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,17 +1,23 @@
-let angular = require('./angular-fix');
-require('angular-mocks/angular-mocks');
-window.apiCheck = require('api-check');
-const chai = require('chai');
-const sinonChai = require('sinon-chai');
-window.expect = chai.expect;
+// Load up the 'test environment' with angular mocks, which in turn needs angular in context
+import angular from 'angular-fix';
+import angularMocks from 'angular-mocks/angular-mocks';
+
+// Load up the angular formly module
+import index from './index.common';
+
+// Bring in the test suites
+import './providers/formlyApiCheck.test';
+import './providers/formlyConfig.test';
+import './services/formlyUtil.test';
+import './directives/formly-custom-validation.test';
+import './directives/formly-field.test';
+import './directives/formly-form.test';
+import './run/formlyNgModelAttrsManipulator.test';
+
+// Use sinonChai for assertions
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+
 chai.use(sinonChai);
 
-require('./providers/formlyApiCheck.test');
-require('./providers/formlyConfig.test');
-require('./services/formlyUtil.test');
-require('./directives/formly-custom-validation.test');
-require('./directives/formly-field.test');
-require('./directives/formly-form.test');
-require('./run/formlyNgModelAttrsManipulator.test');
-
-module.exports = require('./index.common');
+export default index;

--- a/src/other/utils.js
+++ b/src/other/utils.js
@@ -1,5 +1,7 @@
 import angular from 'angular-fix';
 
+export default {formlyEval, getFieldId, reverseDeepMerge, findByNodeName};
+
 function formlyEval(scope, expression, $modelValue, $viewValue) {
   if (angular.isFunction(expression)) {
     return expression($viewValue, $modelValue, scope);
@@ -58,5 +60,3 @@ function findByNodeName(el, nodeName) {
     }
   }
 }
-
-export default {formlyEval, getFieldId, reverseDeepMerge, findByNodeName};

--- a/src/other/utils.js
+++ b/src/other/utils.js
@@ -1,6 +1,4 @@
-const angular = require('angular-fix');
-
-export default {formlyEval, getFieldId, reverseDeepMerge, findByNodeName};
+import angular from 'angular-fix';
 
 function formlyEval(scope, expression, $modelValue, $viewValue) {
   if (angular.isFunction(expression)) {
@@ -60,3 +58,5 @@ function findByNodeName(el, nodeName) {
     }
   }
 }
+
+export default {formlyEval, getFieldId, reverseDeepMerge, findByNodeName};

--- a/src/providers/formlyApiCheck.js
+++ b/src/providers/formlyApiCheck.js
@@ -1,159 +1,155 @@
-module.exports = ngModule => {
+import apiCheckFactory from 'api-check';
 
-  let apiCheck = require('api-check')({
-    output: {
-      prefix: 'angular-formly:',
-      docsBaseUrl: require('../other/docsBaseUrl')
-    }
-  });
-
-  function shapeRequiredIfNot(otherProps, propChecker) {
-    if (!angular.isArray(otherProps)) {
-      otherProps = [otherProps];
-    }
-    const type = `specified if these are not specified: \`${otherProps.join(', ')}\` (otherwise it's optional)`;
-    function shapeRequiredIfNotDefinition(prop, propName, location, obj) {
-      var propExists = obj && obj.hasOwnProperty(propName);
-      var otherPropsExist = otherProps.some(function (otherProp) {
-        return obj && obj.hasOwnProperty(otherProp);
-      });
-      //console.log(propName, propExists, prop, otherPropsExist, otherProps.join(', '));
-      if (!otherPropsExist && !propExists) {
-        return apiCheck.utils.getError(propName, location, type);
-      } else if (propExists) {
-        return propChecker(prop, propName, location, obj);
-      }
-    }
-    shapeRequiredIfNotDefinition.type = type;
-    return apiCheck.utils.checkerHelpers.setupChecker(shapeRequiredIfNotDefinition);
+let apiCheck = apiCheckFactory({
+  output: {
+    prefix: 'angular-formly:',
+    docsBaseUrl: require('../other/docsBaseUrl')
   }
+});
 
-  ngModule.constant('formlyApiCheck', apiCheck);
-  if (ON_TEST) {
-    require('./formlyApiCheck.test')(ngModule);
+function shapeRequiredIfNot(otherProps, propChecker) {
+  if (!angular.isArray(otherProps)) {
+    otherProps = [otherProps];
   }
+  const type = `specified if these are not specified: \`${otherProps.join(', ')}\` (otherwise it's optional)`;
+  function shapeRequiredIfNotDefinition(prop, propName, location, obj) {
+    var propExists = obj && obj.hasOwnProperty(propName);
+    var otherPropsExist = otherProps.some(function (otherProp) {
+      return obj && obj.hasOwnProperty(otherProp);
+    });
+    //console.log(propName, propExists, prop, otherPropsExist, otherProps.join(', '));
+    if (!otherPropsExist && !propExists) {
+      return apiCheck.utils.getError(propName, location, type);
+    } else if (propExists) {
+      return propChecker(prop, propName, location, obj);
+    }
+  }
+  shapeRequiredIfNotDefinition.type = type;
+  return apiCheck.utils.checkerHelpers.setupChecker(shapeRequiredIfNotDefinition);
+}
 
-  let formlyExpression = apiCheck.oneOfType([apiCheck.string, apiCheck.func]);
-  let specifyWrapperType = apiCheck.oneOfType([
-    apiCheck.oneOf([null]), apiCheck.typeOrArrayOf(apiCheck.string)
-  ]);
+let formlyExpression = apiCheck.oneOfType([apiCheck.string, apiCheck.func]);
+let specifyWrapperType = apiCheck.oneOfType([
+  apiCheck.oneOf([null]), apiCheck.typeOrArrayOf(apiCheck.string)
+]);
 
-  const apiCheckProperty = apiCheck.objectOf(apiCheck.func);
+const apiCheckProperty = apiCheck.objectOf(apiCheck.func);
 
-  const apiCheckInstanceProperty = apiCheck.shape.onlyIf('apiCheck', apiCheck.func.withProperties({
-    warn: apiCheck.func,
-    throw: apiCheck.func,
-    shape: apiCheck.func
-  }));
+const apiCheckInstanceProperty = apiCheck.shape.onlyIf('apiCheck', apiCheck.func.withProperties({
+  warn: apiCheck.func,
+  throw: apiCheck.func,
+  shape: apiCheck.func
+}));
 
-  const apiCheckFunctionProperty = apiCheck.shape.onlyIf('apiCheck', apiCheck.oneOf(['throw', 'warn']));
+const apiCheckFunctionProperty = apiCheck.shape.onlyIf('apiCheck', apiCheck.oneOf(['throw', 'warn']));
 
-  const formlyWrapperType = apiCheck.shape({
-    name: shapeRequiredIfNot('types', apiCheck.string).optional,
-    template: apiCheck.shape.ifNot('templateUrl', apiCheck.string).optional,
-    templateUrl: apiCheck.shape.ifNot('template', apiCheck.string).optional,
-    types: apiCheck.typeOrArrayOf(apiCheck.string).optional,
-    overwriteOk: apiCheck.bool.optional,
-    validateOptions: apiCheck.func.optional,
-    apiCheck: apiCheckProperty.optional,
-    apiCheckInstance: apiCheckInstanceProperty.optional,
-    apiCheckFunction: apiCheckFunctionProperty.optional,
-    apiCheckOptions: apiCheck.object.optional
-  }).strict;
+const formlyWrapperType = apiCheck.shape({
+  name: shapeRequiredIfNot('types', apiCheck.string).optional,
+  template: apiCheck.shape.ifNot('templateUrl', apiCheck.string).optional,
+  templateUrl: apiCheck.shape.ifNot('template', apiCheck.string).optional,
+  types: apiCheck.typeOrArrayOf(apiCheck.string).optional,
+  overwriteOk: apiCheck.bool.optional,
+  validateOptions: apiCheck.func.optional,
+  apiCheck: apiCheckProperty.optional,
+  apiCheckInstance: apiCheckInstanceProperty.optional,
+  apiCheckFunction: apiCheckFunctionProperty.optional,
+  apiCheckOptions: apiCheck.object.optional
+}).strict;
 
-  let fieldOptionsApiShape = {
-    type: apiCheck.shape.ifNot(['template', 'templateUrl'], apiCheck.string).optional,
-    template: apiCheck.shape.ifNot(['type', 'templateUrl'], apiCheck.string).optional,
-    templateUrl: apiCheck.shape.ifNot(['type', 'template'], apiCheck.string).optional,
-    key: apiCheck.oneOfType([apiCheck.string, apiCheck.number]),
-    model: apiCheck.object.optional,
-    expressionProperties: apiCheck.objectOf(apiCheck.oneOfType([
-      formlyExpression,
-      apiCheck.shape({
-        expression: formlyExpression,
-        message: formlyExpression.optional
-      }).strict
-    ])).optional,
-    data: apiCheck.object.optional,
-    templateOptions: apiCheck.object.optional,
-    wrapper: specifyWrapperType.optional,
-    modelOptions: apiCheck.shape({
-      updateOn: apiCheck.string.optional,
-      debounce: apiCheck.oneOfType([
-        apiCheck.object, apiCheck.string
-      ]).optional,
-      allowInvalid: apiCheck.bool.optional,
-      getterSetter: apiCheck.bool.optional,
-      timezone: apiCheck.string.optional
-    }).optional,
-    watcher: apiCheck.typeOrArrayOf(
-      apiCheck.shape({
-        expression: formlyExpression.optional,
-        listener: formlyExpression
-      })
-    ).optional,
-    validators: apiCheck.objectOf(apiCheck.oneOfType([
-      formlyExpression, apiCheck.shape({
-        expression: formlyExpression,
-        message: formlyExpression.optional
-      }).strict
-    ])).optional,
-    noFormControl: apiCheck.bool.optional,
-    hide: apiCheck.bool.optional,
-    ngModelAttrs: apiCheck.objectOf(apiCheck.shape({
-      expression: apiCheck.shape.ifNot(['value', 'attribute', 'bound'], apiCheck.any).optional,
-      value: apiCheck.shape.ifNot('expression', apiCheck.any).optional,
-      attribute: apiCheck.shape.ifNot('expression', apiCheck.any).optional,
-      bound: apiCheck.shape.ifNot('expression', apiCheck.any).optional
-    }).strict).optional,
-    optionsTypes: apiCheck.typeOrArrayOf(apiCheck.string).optional,
-    link: apiCheck.func.optional,
-    controller: apiCheck.oneOfType([
-      apiCheck.string, apiCheck.func, apiCheck.array
+let fieldOptionsApiShape = {
+  type: apiCheck.shape.ifNot(['template', 'templateUrl'], apiCheck.string).optional,
+  template: apiCheck.shape.ifNot(['type', 'templateUrl'], apiCheck.string).optional,
+  templateUrl: apiCheck.shape.ifNot(['type', 'template'], apiCheck.string).optional,
+  key: apiCheck.oneOfType([apiCheck.string, apiCheck.number]),
+  model: apiCheck.object.optional,
+  expressionProperties: apiCheck.objectOf(apiCheck.oneOfType([
+    formlyExpression,
+    apiCheck.shape({
+      expression: formlyExpression,
+      message: formlyExpression.optional
+    }).strict
+  ])).optional,
+  data: apiCheck.object.optional,
+  templateOptions: apiCheck.object.optional,
+  wrapper: specifyWrapperType.optional,
+  modelOptions: apiCheck.shape({
+    updateOn: apiCheck.string.optional,
+    debounce: apiCheck.oneOfType([
+      apiCheck.object, apiCheck.string
     ]).optional,
-    validation: apiCheck.shape({
-      show: apiCheck.oneOfType([
-        apiCheck.bool, apiCheck.oneOf([null])
-      ]).optional,
-      messages: apiCheck.objectOf(formlyExpression).optional,
-      errorExistsAndShouldBeVisible: apiCheck.bool.optional
-    }).optional,
-    formControl: apiCheck.object.optional,
-    value: apiCheck.func.optional,
-    runExpressions: apiCheck.func.optional,
-    resetModel: apiCheck.func.optional,
-    updateInitialValue: apiCheck.func.optional,
-    initialValue: apiCheck.any.optional
-  };
-
-  let formlyFieldOptions = apiCheck.shape(fieldOptionsApiShape).strict;
-
-  let typeOptionsDefaultOptions = angular.copy(fieldOptionsApiShape);
-  typeOptionsDefaultOptions.key = apiCheck.string.optional;
-
-  let formlyTypeOptions = apiCheck.shape({
-    name: apiCheck.string,
-    template: apiCheck.shape.ifNot('templateUrl', apiCheck.string).optional,
-    templateUrl: apiCheck.shape.ifNot('template', apiCheck.string).optional,
-    controller: apiCheck.oneOfType([
-      apiCheck.func, apiCheck.string, apiCheck.array
+    allowInvalid: apiCheck.bool.optional,
+    getterSetter: apiCheck.bool.optional,
+    timezone: apiCheck.string.optional
+  }).optional,
+  watcher: apiCheck.typeOrArrayOf(
+    apiCheck.shape({
+      expression: formlyExpression.optional,
+      listener: formlyExpression
+    })
+  ).optional,
+  validators: apiCheck.objectOf(apiCheck.oneOfType([
+    formlyExpression, apiCheck.shape({
+      expression: formlyExpression,
+      message: formlyExpression.optional
+    }).strict
+  ])).optional,
+  noFormControl: apiCheck.bool.optional,
+  hide: apiCheck.bool.optional,
+  ngModelAttrs: apiCheck.objectOf(apiCheck.shape({
+    expression: apiCheck.shape.ifNot(['value', 'attribute', 'bound'], apiCheck.any).optional,
+    value: apiCheck.shape.ifNot('expression', apiCheck.any).optional,
+    attribute: apiCheck.shape.ifNot('expression', apiCheck.any).optional,
+    bound: apiCheck.shape.ifNot('expression', apiCheck.any).optional
+  }).strict).optional,
+  optionsTypes: apiCheck.typeOrArrayOf(apiCheck.string).optional,
+  link: apiCheck.func.optional,
+  controller: apiCheck.oneOfType([
+    apiCheck.string, apiCheck.func, apiCheck.array
+  ]).optional,
+  validation: apiCheck.shape({
+    show: apiCheck.oneOfType([
+      apiCheck.bool, apiCheck.oneOf([null])
     ]).optional,
-    link: apiCheck.func.optional,
-    defaultOptions: apiCheck.oneOfType([
-      apiCheck.func, apiCheck.shape(typeOptionsDefaultOptions)
-    ]).optional,
-    extends: apiCheck.string.optional,
-    wrapper: specifyWrapperType.optional,
-    data: apiCheck.object.optional,
-    validateOptions: apiCheck.func.optional,
-    apiCheck: apiCheckProperty.optional,
-    apiCheckInstance: apiCheckInstanceProperty.optional,
-    apiCheckFunction: apiCheckFunctionProperty.optional,
-    apiCheckOptions: apiCheck.object.optional,
-    overwriteOk: apiCheck.bool.optional
-  }).strict;
-
-  angular.extend(apiCheck, {
-    formlyTypeOptions, formlyFieldOptions, formlyExpression, formlyWrapperType
-  });
+    messages: apiCheck.objectOf(formlyExpression).optional,
+    errorExistsAndShouldBeVisible: apiCheck.bool.optional
+  }).optional,
+  formControl: apiCheck.object.optional,
+  value: apiCheck.func.optional,
+  runExpressions: apiCheck.func.optional,
+  resetModel: apiCheck.func.optional,
+  updateInitialValue: apiCheck.func.optional,
+  initialValue: apiCheck.any.optional
 };
+
+let formlyFieldOptions = apiCheck.shape(fieldOptionsApiShape).strict;
+
+let typeOptionsDefaultOptions = angular.copy(fieldOptionsApiShape);
+typeOptionsDefaultOptions.key = apiCheck.string.optional;
+
+let formlyTypeOptions = apiCheck.shape({
+  name: apiCheck.string,
+  template: apiCheck.shape.ifNot('templateUrl', apiCheck.string).optional,
+  templateUrl: apiCheck.shape.ifNot('template', apiCheck.string).optional,
+  controller: apiCheck.oneOfType([
+    apiCheck.func, apiCheck.string, apiCheck.array
+  ]).optional,
+  link: apiCheck.func.optional,
+  defaultOptions: apiCheck.oneOfType([
+    apiCheck.func, apiCheck.shape(typeOptionsDefaultOptions)
+  ]).optional,
+  extends: apiCheck.string.optional,
+  wrapper: specifyWrapperType.optional,
+  data: apiCheck.object.optional,
+  validateOptions: apiCheck.func.optional,
+  apiCheck: apiCheckProperty.optional,
+  apiCheckInstance: apiCheckInstanceProperty.optional,
+  apiCheckFunction: apiCheckFunctionProperty.optional,
+  apiCheckOptions: apiCheck.object.optional,
+  overwriteOk: apiCheck.bool.optional
+}).strict;
+
+angular.extend(apiCheck, {
+  formlyTypeOptions, formlyFieldOptions, formlyExpression, formlyWrapperType
+});
+
+export default apiCheck;

--- a/src/providers/formlyApiCheck.test.js
+++ b/src/providers/formlyApiCheck.test.js
@@ -1,4 +1,6 @@
 /* jshint maxlen:false */
+import {expect} from 'chai';
+
 describe('formlyApiCheck', () => {
   beforeEach(window.module('formly'));
 

--- a/src/providers/formlyApiCheck.test.js
+++ b/src/providers/formlyApiCheck.test.js
@@ -1,28 +1,26 @@
 /* jshint maxlen:false */
-module.exports = ngModule => {
-  describe('formlyApiCheck', () => {
-    beforeEach(window.module(ngModule.name));
+describe('formlyApiCheck', () => {
+  beforeEach(window.module('formly'));
 
-    describe('formlyFieldOptions', () => {
-      let formlyFieldOptions;
-      beforeEach(inject((formlyApiCheck) => {
-        formlyFieldOptions = formlyApiCheck.formlyFieldOptions;
-      }));
+  describe('formlyFieldOptions', () => {
+    let formlyFieldOptions;
+    beforeEach(inject((formlyApiCheck) => {
+      formlyFieldOptions = formlyApiCheck.formlyFieldOptions;
+    }));
 
-      it(`should pass when validation.messages is an object of functions or strings`, () => {
-        const options = {
-          key: '♪┏(・o･)┛♪┗ ( ･o･) ┓♪',
-          validation: {
-            messages: {
-              thing1() {
-              },
-              thing2: '"Formly Expression"'
-            }
+    it(`should pass when validation.messages is an object of functions or strings`, () => {
+      const options = {
+        key: '♪┏(・o･)┛♪┗ ( ･o･) ┓♪',
+        validation: {
+          messages: {
+            thing1() {
+            },
+            thing2: '"Formly Expression"'
           }
-        };
-        const result = formlyFieldOptions(options);
-        expect(result).to.be.undefined;
-      });
+        }
+      };
+      const result = formlyFieldOptions(options);
+      expect(result).to.be.undefined;
     });
   });
-};
+});

--- a/src/providers/formlyConfig.js
+++ b/src/providers/formlyConfig.js
@@ -1,282 +1,275 @@
-const angular = require('angular-fix');
-const utils = require('../other/utils');
+import angular from 'angular-fix';
+import utils from '../other/utils';
 
-module.exports = ngModule => {
-  ngModule.provider('formlyConfig', formlyConfig);
+function formlyConfig(formlyUsabilityProvider, formlyApiCheck) {
 
-  formlyConfig.tests = ON_TEST ? require('./formlyConfig.test')(ngModule) : null;
+  var typeMap = {};
+  var templateWrappersMap = {};
+  var defaultWrapperName = 'default';
+  var _this = this;
+  var getError = formlyUsabilityProvider.getFormlyError;
 
-  function formlyConfig(formlyUsabilityProvider, formlyApiCheck) {
+  angular.extend(this, {
+    setType,
+    getType,
+    setWrapper,
+    getWrapper,
+    getWrapperByType,
+    removeWrapperByName,
+    removeWrappersForType,
+    disableWarnings: false,
+    extras: {
+      disableNgModelAttrsManipulator: false,
+      ngModelAttrsManipulatorPreferUnbound: false,
+      removeChromeAutoComplete: false
+    },
+    templateManipulators: {
+      preWrapper: [],
+      postWrapper: []
+    },
+    $get: () => this
+  });
 
-    var typeMap = {};
-    var templateWrappersMap = {};
-    var defaultWrapperName = 'default';
-    var _this = this;
-    var getError = formlyUsabilityProvider.getFormlyError;
+  function setType(options) {
+    if (angular.isArray(options)) {
+      angular.forEach(options, setType);
+    } else if (angular.isObject(options)) {
+      checkType(options);
+      if (options.extends) {
+        extendTypeOptions(options);
+      }
+      typeMap[options.name] = options;
+    } else {
+      throw getError(`You must provide an object or array for setType. You provided: ${JSON.stringify(arguments)}`);
+    }
+  }
 
-    angular.extend(this, {
-      setType,
-      getType,
-      setWrapper,
-      getWrapper,
-      getWrapperByType,
-      removeWrapperByName,
-      removeWrappersForType,
-      disableWarnings: false,
-      extras: {
-        disableNgModelAttrsManipulator: false,
-        ngModelAttrsManipulatorPreferUnbound: false,
-        removeChromeAutoComplete: false
-      },
-      templateManipulators: {
-        preWrapper: [],
-        postWrapper: []
-      },
-      $get: () => this
+  function checkType(options) {
+    formlyApiCheck.throw(formlyApiCheck.formlyTypeOptions, options, {
+      prefix: 'formlyConfig.setType',
+      url: 'settype-validation-failed'
     });
-
-    function setType(options) {
-      if (angular.isArray(options)) {
-        angular.forEach(options, setType);
-      } else if (angular.isObject(options)) {
-        checkType(options);
-        if (options.extends) {
-          extendTypeOptions(options);
-        }
-        typeMap[options.name] = options;
-      } else {
-        throw getError(`You must provide an object or array for setType. You provided: ${JSON.stringify(arguments)}`);
-      }
+    if (!options.overwriteOk) {
+      checkOverwrite(options.name, typeMap, options, 'types');
+    } else {
+      options.overwriteOk = undefined;
     }
+  }
 
-    function checkType(options) {
-      formlyApiCheck.throw(formlyApiCheck.formlyTypeOptions, options, {
-        prefix: 'formlyConfig.setType',
-        url: 'settype-validation-failed'
+  function extendTypeOptions(options) {
+    const extendsType = getType(options.extends, true, options);
+    extendTypeControllerFunction(options, extendsType);
+    extendTypeLinkFunction(options, extendsType);
+    extendTypeValidateOptionsFunction(options, extendsType);
+    extendTypeDefaultOptions(options, extendsType);
+    utils.reverseDeepMerge(options, extendsType);
+  }
+
+  function extendTypeControllerFunction(options, extendsType) {
+    const extendsCtrl = extendsType.controller;
+    if (!angular.isDefined(extendsCtrl)) {
+      return;
+    }
+    const optionsCtrl = options.controller;
+    if (angular.isDefined(optionsCtrl)) {
+      options.controller = function ($scope, $controller) {
+        $controller(extendsCtrl, {$scope});
+        $controller(optionsCtrl, {$scope});
+      };
+      options.controller.$inject = ['$scope', '$controller'];
+    } else {
+      options.controller = extendsCtrl;
+    }
+  }
+
+  function extendTypeLinkFunction(options, extendsType) {
+    const extendsFn = extendsType.link;
+    if (!angular.isDefined(extendsFn)) {
+      return;
+    }
+    const optionsFn = options.link;
+    if (angular.isDefined(optionsFn)) {
+      options.link = function () {
+        extendsFn(...arguments);
+        optionsFn(...arguments);
+      };
+    } else {
+      options.link = extendsFn;
+    }
+  }
+
+  function extendTypeValidateOptionsFunction(options, extendsType) {
+    const extendsFn = extendsType.validateOptions;
+    if (!angular.isDefined(extendsFn)) {
+      return;
+    }
+    const optionsFn = options.validateOptions;
+    const originalDefaultOptions = options.defaultOptions;
+    if (angular.isDefined(optionsFn)) {
+      options.validateOptions = function (options) {
+        optionsFn(options);
+        let mergedOptions = angular.copy(options);
+        let defaultOptions = originalDefaultOptions;
+        if (defaultOptions) {
+          if (angular.isFunction(defaultOptions)) {
+            defaultOptions = defaultOptions(mergedOptions);
+          }
+          utils.reverseDeepMerge(mergedOptions, defaultOptions);
+        }
+        extendsFn(mergedOptions);
+      };
+    } else {
+      options.validateOptions = extendsFn;
+    }
+  }
+
+  function extendTypeDefaultOptions(options, extendsType) {
+    const extendsDO = extendsType.defaultOptions;
+    if (!angular.isDefined(extendsDO)) {
+      return;
+    }
+    const optionsDO = options.defaultOptions;
+    const optionsDOIsFn = angular.isFunction(optionsDO);
+    const extendsDOIsFn = angular.isFunction(extendsDO);
+    if (extendsDOIsFn) {
+      options.defaultOptions = function defaultOptions(options) {
+        const extendsDefaultOptions = extendsDO(options);
+        const mergedDefaultOptions = {};
+        utils.reverseDeepMerge(mergedDefaultOptions, options, extendsDefaultOptions);
+        let extenderOptionsDefaultOptions = optionsDO;
+        if (optionsDOIsFn) {
+          extenderOptionsDefaultOptions = extenderOptionsDefaultOptions(mergedDefaultOptions);
+        }
+        utils.reverseDeepMerge(extendsDefaultOptions, extenderOptionsDefaultOptions);
+        return extendsDefaultOptions;
+      };
+    } else if (optionsDOIsFn) {
+      options.defaultOptions = function defaultOptions(options) {
+        let newDefaultOptions = {};
+        utils.reverseDeepMerge(newDefaultOptions, options, extendsDO);
+        return optionsDO(newDefaultOptions);
+      };
+    }
+  }
+
+  function getType(name, throwError, errorContext) {
+    if (!name) {
+      return undefined;
+    }
+    var type = typeMap[name];
+    if (!type && throwError === true) {
+      throw getError(
+        `There is no type by the name of "${name}": ${JSON.stringify(errorContext)}`
+      );
+    } else {
+      return type;
+    }
+  }
+
+  function setWrapper(options, name) {
+    if (angular.isArray(options)) {
+      return options.map(wrapperOptions => setWrapper(wrapperOptions));
+    } else if (angular.isObject(options)) {
+      options.types = getOptionsTypes(options);
+      options.name = getOptionsName(options, name);
+      checkWrapperAPI(options);
+      templateWrappersMap[options.name] = options;
+      return options;
+    } else if (angular.isString(options)) {
+      return setWrapper({
+        template: options,
+        name
       });
-      if (!options.overwriteOk) {
-        checkOverwrite(options.name, typeMap, options, 'types');
-      } else {
-        options.overwriteOk = undefined;
-      }
     }
+  }
 
-    function extendTypeOptions(options) {
-      const extendsType = getType(options.extends, true, options);
-      extendTypeControllerFunction(options, extendsType);
-      extendTypeLinkFunction(options, extendsType);
-      extendTypeValidateOptionsFunction(options, extendsType);
-      extendTypeDefaultOptions(options, extendsType);
-      utils.reverseDeepMerge(options, extendsType);
+  function getOptionsTypes(options) {
+    if (angular.isString(options.types)) {
+      return [options.types];
     }
-
-    function extendTypeControllerFunction(options, extendsType) {
-      const extendsCtrl = extendsType.controller;
-      if (!angular.isDefined(extendsCtrl)) {
-        return;
-      }
-      const optionsCtrl = options.controller;
-      if (angular.isDefined(optionsCtrl)) {
-        options.controller = function($scope, $controller) {
-          $controller(extendsCtrl, {$scope});
-          $controller(optionsCtrl, {$scope});
-        };
-        options.controller.$inject = ['$scope', '$controller'];
-      } else {
-        options.controller = extendsCtrl;
-      }
+    if (!angular.isDefined(options.types)) {
+      return [];
+    } else {
+      return options.types;
     }
+  }
 
-    function extendTypeLinkFunction(options, extendsType) {
-      const extendsFn = extendsType.link;
-      if (!angular.isDefined(extendsFn)) {
-        return;
-      }
-      const optionsFn = options.link;
-      if (angular.isDefined(optionsFn)) {
-        options.link = function() {
-          extendsFn(...arguments);
-          optionsFn(...arguments);
-        };
-      } else {
-        options.link = extendsFn;
-      }
+  function getOptionsName(options, name) {
+    return options.name || name || options.types.join(' ') || defaultWrapperName;
+  }
+
+  function checkWrapperAPI(options) {
+    formlyUsabilityProvider.checkWrapper(options);
+    if (options.template) {
+      formlyUsabilityProvider.checkWrapperTemplate(options.template, options);
     }
-
-    function extendTypeValidateOptionsFunction(options, extendsType) {
-      const extendsFn = extendsType.validateOptions;
-      if (!angular.isDefined(extendsFn)) {
-        return;
-      }
-      const optionsFn = options.validateOptions;
-      const originalDefaultOptions = options.defaultOptions;
-      if (angular.isDefined(optionsFn)) {
-        options.validateOptions = function(options) {
-          optionsFn(options);
-          let mergedOptions = angular.copy(options);
-          let defaultOptions = originalDefaultOptions;
-          if (defaultOptions) {
-            if (angular.isFunction(defaultOptions)) {
-              defaultOptions = defaultOptions(mergedOptions);
-            }
-            utils.reverseDeepMerge(mergedOptions, defaultOptions);
-          }
-          extendsFn(mergedOptions);
-        };
-      } else {
-        options.validateOptions = extendsFn;
-      }
+    if (!options.overwriteOk) {
+      checkOverwrite(options.name, templateWrappersMap, options, 'templateWrappers');
+    } else {
+      delete options.overwriteOk;
     }
+    checkWrapperTypes(options);
+  }
 
-    function extendTypeDefaultOptions(options, extendsType) {
-      const extendsDO = extendsType.defaultOptions;
-      if (!angular.isDefined(extendsDO)) {
-        return;
-      }
-      const optionsDO = options.defaultOptions;
-      const optionsDOIsFn = angular.isFunction(optionsDO);
-      const extendsDOIsFn = angular.isFunction(extendsDO);
-      if (extendsDOIsFn) {
-        options.defaultOptions = function defaultOptions(options) {
-          const extendsDefaultOptions = extendsDO(options);
-          const mergedDefaultOptions = {};
-          utils.reverseDeepMerge(mergedDefaultOptions, options, extendsDefaultOptions);
-          let extenderOptionsDefaultOptions = optionsDO;
-          if (optionsDOIsFn) {
-            extenderOptionsDefaultOptions = extenderOptionsDefaultOptions(mergedDefaultOptions);
-          }
-          utils.reverseDeepMerge(extendsDefaultOptions, extenderOptionsDefaultOptions);
-          return extendsDefaultOptions;
-        };
-      } else if (optionsDOIsFn) {
-        options.defaultOptions = function defaultOptions(options) {
-          let newDefaultOptions = {};
-          utils.reverseDeepMerge(newDefaultOptions, options, extendsDO);
-          return optionsDO(newDefaultOptions);
-        };
-      }
+  function checkWrapperTypes(options) {
+    let shouldThrow = !angular.isArray(options.types) || !options.types.every(angular.isString);
+    if (shouldThrow) {
+      throw getError(`Attempted to create a template wrapper with types that is not a string or an array of strings`);
     }
+  }
 
-    function getType(name, throwError, errorContext) {
-      if (!name) {
-        return undefined;
-      }
-      var type = typeMap[name];
-      if (!type && throwError === true) {
-        throw getError(
-          `There is no type by the name of "${name}": ${JSON.stringify(errorContext)}`
-        );
-      } else {
-        return type;
-      }
+  function checkOverwrite(property, object, newValue, objectName) {
+    if (object.hasOwnProperty(property)) {
+      warn([
+        `Attempting to overwrite ${property} on ${objectName} which is currently`,
+        `${JSON.stringify(object[property])} with ${JSON.stringify(newValue)}`,
+        `To supress this warning, specify the property "overwriteOk: true"`
+      ].join(' '));
     }
+  }
 
-    function setWrapper(options, name) {
-      if (angular.isArray(options)) {
-        return options.map(wrapperOptions => setWrapper(wrapperOptions));
-      } else if (angular.isObject(options)) {
-        options.types = getOptionsTypes(options);
-        options.name = getOptionsName(options, name);
-        checkWrapperAPI(options);
-        templateWrappersMap[options.name] = options;
-        return options;
-      } else if (angular.isString(options)) {
-        return setWrapper({
-          template: options,
-          name
-        });
-      }
-    }
+  function getWrapper(name) {
+    return templateWrappersMap[name || defaultWrapperName];
+  }
 
-    function getOptionsTypes(options) {
-      if (angular.isString(options.types)) {
-        return [options.types];
-      }
-      if (!angular.isDefined(options.types)) {
-        return [];
-      } else {
-        return options.types;
-      }
-    }
-
-    function getOptionsName(options, name) {
-      return options.name || name || options.types.join(' ') || defaultWrapperName;
-    }
-
-    function checkWrapperAPI(options) {
-      formlyUsabilityProvider.checkWrapper(options);
-      if (options.template) {
-        formlyUsabilityProvider.checkWrapperTemplate(options.template, options);
-      }
-      if (!options.overwriteOk) {
-        checkOverwrite(options.name, templateWrappersMap, options, 'templateWrappers');
-      } else {
-        delete options.overwriteOk;
-      }
-      checkWrapperTypes(options);
-    }
-
-    function checkWrapperTypes(options) {
-      let shouldThrow = !angular.isArray(options.types) || !options.types.every(angular.isString);
-      if (shouldThrow) {
-        throw getError(`Attempted to create a template wrapper with types that is not a string or an array of strings`);
-      }
-    }
-
-    function checkOverwrite(property, object, newValue, objectName) {
-      if (object.hasOwnProperty(property)) {
-        warn([
-          `Attempting to overwrite ${property} on ${objectName} which is currently`,
-          `${JSON.stringify(object[property])} with ${JSON.stringify(newValue)}`,
-          `To supress this warning, specify the property "overwriteOk: true"`
-        ].join(' '));
-      }
-    }
-
-    function getWrapper(name) {
-      return templateWrappersMap[name || defaultWrapperName];
-    }
-
-    function getWrapperByType(type) {
-      /* jshint maxcomplexity:6 */
-      var wrappers = [];
-      for (var name in templateWrappersMap) {
-        if (templateWrappersMap.hasOwnProperty(name)) {
-          if (templateWrappersMap[name].types && templateWrappersMap[name].types.indexOf(type) !== -1) {
-            wrappers.push(templateWrappersMap[name]);
-          }
+  function getWrapperByType(type) {
+    /* jshint maxcomplexity:6 */
+    var wrappers = [];
+    for (var name in templateWrappersMap) {
+      if (templateWrappersMap.hasOwnProperty(name)) {
+        if (templateWrappersMap[name].types && templateWrappersMap[name].types.indexOf(type) !== -1) {
+          wrappers.push(templateWrappersMap[name]);
         }
       }
+    }
+    return wrappers;
+  }
+
+  function removeWrapperByName(name) {
+    var wrapper = templateWrappersMap[name];
+    delete templateWrappersMap[name];
+    return wrapper;
+  }
+
+  function removeWrappersForType(type) {
+    var wrappers = getWrapperByType(type);
+    if (!wrappers) {
+      return;
+    }
+    if (!angular.isArray(wrappers)) {
+      return removeWrapperByName(wrappers.name);
+    } else {
+      wrappers.forEach((wrapper) => removeWrapperByName(wrapper.name));
       return wrappers;
-    }
-
-    function removeWrapperByName(name) {
-      var wrapper = templateWrappersMap[name];
-      delete templateWrappersMap[name];
-      return wrapper;
-    }
-
-    function removeWrappersForType(type) {
-      var wrappers = getWrapperByType(type);
-      if (!wrappers) {
-        return;
-      }
-      if (!angular.isArray(wrappers)) {
-        return removeWrapperByName(wrappers.name);
-      } else {
-        wrappers.forEach((wrapper) => removeWrapperByName(wrapper.name));
-        return wrappers;
-      }
-    }
-
-
-    function warn() {
-      if (!_this.disableWarnings) {
-        console.warn(...arguments);
-      }
     }
   }
 
 
+  function warn() {
+    if (!_this.disableWarnings) {
+      console.warn(...arguments);
+    }
+  }
+}
 
-};
+export default formlyConfig;

--- a/src/providers/formlyConfig.js
+++ b/src/providers/formlyConfig.js
@@ -1,7 +1,7 @@
 import angular from 'angular-fix';
 import utils from '../other/utils';
 
-function formlyConfig(formlyUsabilityProvider, formlyApiCheck) {
+export default function formlyConfig(formlyUsabilityProvider, formlyApiCheck) {
 
   var typeMap = {};
   var templateWrappersMap = {};
@@ -271,5 +271,3 @@ function formlyConfig(formlyUsabilityProvider, formlyApiCheck) {
     }
   }
 }
-
-export default formlyConfig;

--- a/src/providers/formlyConfig.test.js
+++ b/src/providers/formlyConfig.test.js
@@ -1,631 +1,630 @@
 /* jshint maxlen:false */
-const sinon = require('sinon');
-module.exports = ngModule => {
-  describe('formlyConfig', () => {
-    beforeEach(window.module(ngModule.name));
+import sinon from 'sinon';
 
-    describe('setWrapper/getWrapper', () => {
-      var getterFn, setterFn;
-      var template = '<span>This is my <formly-transclude></formly-transclude> template';
-      var templateUrl = '/path/to/my/template.html';
-      var typesString = 'checkbox';
-      var types = ['text', 'textarea'];
-      var name = 'hi';
-      var name2 = 'name2';
-      var template2 = template + '2';
-      var $log;
-      beforeEach(inject(function(formlyConfig, _$log_) {
-        getterFn = formlyConfig.getWrapper;
-        setterFn = formlyConfig.setWrapper;
-        $log = _$log_;
-      }));
+describe('formlyConfig', () => {
+  beforeEach(window.module('formly'));
 
-      describe('＼(＾O＾)／ path', () => {
-        describe('the default template', () => {
+  describe('setWrapper/getWrapper', () => {
+    var getterFn, setterFn;
+    var template = '<span>This is my <formly-transclude></formly-transclude> template';
+    var templateUrl = '/path/to/my/template.html';
+    var typesString = 'checkbox';
+    var types = ['text', 'textarea'];
+    var name = 'hi';
+    var name2 = 'name2';
+    var template2 = template + '2';
+    var $log;
+    beforeEach(inject(function(formlyConfig, _$log_) {
+      getterFn = formlyConfig.getWrapper;
+      setterFn = formlyConfig.setWrapper;
+      $log = _$log_;
+    }));
 
-          it('can be a string without a name', () => {
-            setterFn(template);
-            expect(getterFn()).to.eql({name: 'default', template, types: []});
-          });
+    describe('＼(＾O＾)／ path', () => {
+      describe('the default template', () => {
 
-          it('can be a string with a name', () => {
-            setterFn(template, name);
-            expect(getterFn(name)).to.eql({name, template, types: []});
-          });
-
-          it('can be an object with a template', () => {
-            setterFn({template});
-            expect(getterFn()).to.eql({name: 'default', template, types: []});
-          });
-
-          it('can be an object with a template and a name', () => {
-            setterFn({template, name});
-            expect(getterFn(name)).to.eql({name, template, types: []});
-          });
-
-          it('can be an object with a templateUrl', () => {
-            setterFn({templateUrl});
-            expect(getterFn()).to.eql({name: 'default', templateUrl, types: []});
-          });
-
-          it('can be an object with a templateUrl and a name', () => {
-            setterFn({name, templateUrl});
-            expect(getterFn(name)).to.eql({name, templateUrl, types: []});
-          });
-
-          it('can be an array of objects with names, urls, and/or templates', () => {
-            setterFn([
-              {templateUrl},
-              {name, template},
-              {name: name2, template: template2}
-            ]);
-            expect(getterFn()).to.eql({templateUrl, name: 'default', types: []});
-            expect(getterFn(name)).to.eql({template, name, types: []});
-            expect(getterFn(name2)).to.eql({template: template2, name: name2, types: []});
-          });
-
-          it('can specify types as a string (using types as the name when not specified)', () => {
-            setterFn({types: typesString, template});
-            expect(getterFn(typesString)).to.eql({template, name: typesString, types: [typesString]});
-          });
-
-          it('can specify types as an array (using types as the name when not specified)', () => {
-            setterFn({types, template});
-            expect(getterFn(types.join(' '))).to.eql({template, name: types.join(' '), types});
-          });
-        });
-      });
-
-      describe('(◞‸◟；) path', () => {
-        it('should throw an error when providing both a template and templateUrl', () => {
-          expect(() => setterFn({template, templateUrl}, name)).to.throw(/template.*?only if templateUrl.*not/i);
+        it('can be a string without a name', () => {
+          setterFn(template);
+          expect(getterFn()).to.eql({name: 'default', template, types: []});
         });
 
-        it('should throw an error when providing neither a template or a templateUrl', () => {
-          expect(() => setterFn({
-            template,
-            templateUrl
-          }, name)).to.throw(/template.*specified only if templateUrl is not specified/i);
+        it('can be a string with a name', () => {
+          setterFn(template, name);
+          expect(getterFn(name)).to.eql({name, template, types: []});
         });
 
-        it('should throw an error when the template does not use formly-transclude', () => {
-          var error = /templates.*?must.*?<formly-transclude><\/formly-transclude>/;
-          expect(() => setterFn({template: 'no formly-transclude'})).to.throw(error);
+        it('can be an object with a template', () => {
+          setterFn({template});
+          expect(getterFn()).to.eql({name: 'default', template, types: []});
         });
 
-        it('should throw an error when specifying an array type where not all items are strings', () => {
-          var error = /types.*?typeOrArrayOf.*?String.*?/i;
-          expect(() => setterFn({template, types: ['hi', 2, false, 'cool']})).to.throw(error);
+        it('can be an object with a template and a name', () => {
+          setterFn({template, name});
+          expect(getterFn(name)).to.eql({name, template, types: []});
         });
 
-        it('should warn when attempting to override a template wrapper', () => {
-          shouldWarn(/overwrite/, function() {
-            setterFn({template});
-            setterFn({template});
-          });
+        it('can be an object with a templateUrl', () => {
+          setterFn({templateUrl});
+          expect(getterFn()).to.eql({name: 'default', templateUrl, types: []});
         });
 
-        it('should not warn when attempting to override a template wrapper if overwriteOk is true', () => {
-          shouldNotWarn(() => {
-            setterFn({template});
-            setterFn({template, overwriteOk: true});
-          });
-        });
-      });
-
-
-      describe(`apiCheck`, () => {
-        testApiCheck('setWrapper', 'getWrapper');
-      });
-
-    });
-
-    describe('getWrapperByType', () => {
-      var getterFn, setterFn;
-      var types = ['input', 'checkbox'];
-      var types2 = ['input', 'select'];
-      var templateUrl = '/path/to/file.html';
-      beforeEach(inject(function(formlyConfig) {
-        setterFn = formlyConfig.setWrapper;
-        getterFn = formlyConfig.getWrapperByType;
-      }));
-
-      describe('＼(＾O＾)／ path', () => {
-        it('should return a template wrapper that has the same type', () => {
-          var option = setterFn({templateUrl, types});
-          expect(getterFn(types[0])).to.eql([option]);
-        });
-
-        it('should return an array when multiple wrappers have the same time', () => {
-          setterFn({templateUrl, types});
-          setterFn({templateUrl, types: types2});
-          var inputWrappers = getterFn('input');
-          expect(inputWrappers).to.be.instanceOf(Array);
-          expect(inputWrappers).to.have.length(2);
-        });
-
-      });
-    });
-
-    describe('removeWrapper', () => {
-      var remove, removeForType, setterFn, getterFn, getByTypeFn;
-      var template = '<div>Something <formly-transclude></formly-transclude> cool</div>';
-      var name = 'name';
-      var types = ['input', 'checkbox'];
-      var types2 = ['input', 'something else'];
-      var types3 = ['checkbox', 'something else'];
-      beforeEach(inject((formlyConfig) => {
-        remove = formlyConfig.removeWrapperByName;
-        removeForType = formlyConfig.removeWrappersForType;
-        setterFn = formlyConfig.setWrapper;
-        getterFn = formlyConfig.getWrapper;
-        getByTypeFn = formlyConfig.getWrapperByType;
-      }));
-
-      it('should allow you to remove a wrapper', () => {
-        setterFn(template, name);
-        remove(name);
-        expect(getterFn(name)).to.be.empty;
-      });
-
-      it('should allow you to remove a wrapper for a type', () => {
-        setterFn({types, template});
-        setterFn({types: types2, template});
-        var checkboxAndSomethingElseWrapper = setterFn({types: types3, template});
-        removeForType('input');
-        expect(getByTypeFn('input')).to.be.empty;
-        var checkboxWrappers = getByTypeFn('checkbox');
-        expect(checkboxWrappers).to.eql([checkboxAndSomethingElseWrapper]);
-      });
-    });
-
-
-    describe('setType/getType', () => {
-      var getterFn, setterFn;
-      var name = 'input';
-      var template = '<input type="{{options.inputType}}" />';
-      var templateUrl = '/input.html';
-      var wrapper = 'input';
-      var wrapper2 = 'input2';
-      beforeEach(inject(function(formlyConfig) {
-        getterFn = formlyConfig.getType;
-        setterFn = formlyConfig.setType;
-      }));
-
-      describe('＼(＾O＾)／ path', () => {
-        it('should accept an object with a name and a template', () => {
-          setterFn({name, template});
-          expect(getterFn(name).template).to.equal(template);
-        });
-
-        it('should accept an object with a name and a templateUrl', () => {
+        it('can be an object with a templateUrl and a name', () => {
           setterFn({name, templateUrl});
-          expect(getterFn(name).templateUrl).to.equal(templateUrl);
+          expect(getterFn(name)).to.eql({name, templateUrl, types: []});
         });
 
-        it('should accept an array of objects', () => {
+        it('can be an array of objects with names, urls, and/or templates', () => {
           setterFn([
+            {templateUrl},
             {name, template},
-            {name: 'type2', templateUrl}
+            {name: name2, template: template2}
           ]);
-          expect(getterFn(name).template).to.equal(template);
-          expect(getterFn('type2').templateUrl).to.equal(templateUrl);
+          expect(getterFn()).to.eql({templateUrl, name: 'default', types: []});
+          expect(getterFn(name)).to.eql({template, name, types: []});
+          expect(getterFn(name2)).to.eql({template: template2, name: name2, types: []});
         });
 
-        it('should allow you to set a wrapper as a string', () => {
-          setterFn({name, template, wrapper});
-          expect(getterFn(name).wrapper).to.equal(wrapper);
+        it('can specify types as a string (using types as the name when not specified)', () => {
+          setterFn({types: typesString, template});
+          expect(getterFn(typesString)).to.eql({template, name: typesString, types: [typesString]});
         });
 
-        it('should allow you to set a wrapper as an array', () => {
-          setterFn({name, template, wrapper: [wrapper, wrapper2]});
-          expect(getterFn(name).wrapper).to.eql([wrapper, wrapper2]);
+        it('can specify types as an array (using types as the name when not specified)', () => {
+          setterFn({types, template});
+          expect(getterFn(types.join(' '))).to.eql({template, name: types.join(' '), types});
         });
-
-        describe(`extends`, () => {
-          describe(`object case`, () => {
-            beforeEach(() => {
-              setterFn([
-                {
-                  name,
-                  template,
-                  defaultOptions: {
-                    templateOptions: {
-                      required: true,
-                      min: 3
-                    }
-                  }
-                },
-                {
-                  name: 'type2',
-                  extends: name,
-                  defaultOptions: {
-                    templateOptions: {
-                      required: false,
-                      max: 4
-                    },
-                    data: {
-                      extraStuff: [1, 2, 3]
-                    }
-                  }
-                }
-              ]);
-            });
-            it(`should inherit all fields that it does not have itself`, () => {
-              expect(getterFn('type2').template).to.eql(template);
-            });
-
-            it(`should merge objects that it shares`, () => {
-              expect(getterFn('type2').defaultOptions).to.eql({
-                templateOptions: {
-                  required: false,
-                  min: 3,
-                  max: 4
-                },
-                data: {
-                  extraStuff: [1, 2, 3]
-                }
-              });
-            });
-
-            it(`should not error when extends is specified without a template, templateUrl, or defaultOptions`, () => {
-              expect(() => setterFn({name: 'type3', extends: 'type2'})).to.not.throw();
-            });
-
-          });
-
-          describe(`function cases`, () => {
-            let args, parentFn, childFn, parentDefaultOptions, childDefaultOptions,
-              argsAndParent;
-            beforeEach(() => {
-              args = {data: {someData: true}};
-              parentDefaultOptions = {
-                data: {extraOptions: true},
-                templateOptions: {placeholder: 'hi'}
-              };
-              childDefaultOptions = {
-                templateOptions: {placeholder: 'hey', required: true}
-              };
-              parentFn = sinon.stub().returns(parentDefaultOptions);
-              childFn = sinon.stub().returns(childDefaultOptions);
-              argsAndParent = {
-                data: {someData: true, extraOptions: true},
-                templateOptions: {placeholder: 'hi'}
-              };
-            });
-
-            it(`should call the extended parent's defaultOptions function and its own defaultOptions function`, () => {
-              setterFn([
-                {name, defaultOptions: parentFn},
-                {name: 'type2', extends: name, defaultOptions: childFn}
-              ]);
-              getterFn('type2').defaultOptions(args);
-              expect(parentFn).to.have.been.calledWith(args);
-              expect(childFn).to.have.been.calledWith(argsAndParent);
-            });
-
-            it(`should call the extended parent's defaultOptions function when it doesn't have one of its own`, () => {
-              setterFn([
-                {name, defaultOptions: parentFn},
-                {name: 'type2', extends: name}
-              ]);
-              getterFn('type2').defaultOptions(args);
-              expect(parentFn).to.have.been.calledWith(args);
-            });
-
-            it(`should call its own defaultOptions function when the parent doesn't have one`, () => {
-              setterFn([
-                {name, template},
-                {name: 'type2', extends: name, defaultOptions: childFn}
-              ]);
-              getterFn('type2').defaultOptions(args);
-              expect(childFn).to.have.been.calledWith(args);
-            });
-
-            it(`should extend its defaultOptions object with the parent's defaultOptions object`, () => {
-              const objectMergedDefaultOptions = {
-                data: {extraOptions: true},
-                templateOptions: {placeholder: 'hey', required: true}
-              };
-              setterFn([
-                {name, defaultOptions: parentDefaultOptions},
-                {name: 'type2', extends: name, defaultOptions: childDefaultOptions}
-              ]);
-              expect(getterFn('type2').defaultOptions).to.eql(objectMergedDefaultOptions);
-            });
-
-            it(`should call its defaultOptions with the parent's defaultOptions object merged with the given args`, () => {
-              setterFn([
-                {name, defaultOptions: parentDefaultOptions},
-                {name: 'type2', extends: name, defaultOptions: childFn}
-              ]);
-              var returned = getterFn('type2').defaultOptions(args);
-              expect(childFn).to.have.been.calledWith(argsAndParent);
-              expect(returned).to.eql(childDefaultOptions);
-            });
-          });
-
-          describe(`link functions`, () => {
-            let linkArgs, parentFn, childFn;
-            beforeEach(inject(($rootScope) => {
-              linkArgs = [$rootScope.$new(), angular.element('<div></div>'), {}];
-              parentFn = sinon.spy();
-              childFn = sinon.spy();
-            }));
-
-            it(`should call the parent link function when there is no child function`, () => {
-              setterFn([
-                {name, template, link: parentFn},
-                {name: 'type2', extends: name}
-              ]);
-              getterFn('type2').link(...linkArgs);
-              expect(parentFn).to.have.been.calledWith(...linkArgs);
-            });
-
-            it(`should call the child link function when there is no parent function`, () => {
-              setterFn([
-                {name, template},
-                {name: 'type2', extends: name, link: childFn}
-              ]);
-              getterFn('type2').link(...linkArgs);
-              expect(childFn).to.have.been.calledWith(...linkArgs);
-            });
-
-            it(`should call the child link function and the parent link function when they are both present`, () => {
-              setterFn([
-                {name, template, link: parentFn},
-                {name: 'type2', extends: name, link: childFn}
-              ]);
-              getterFn('type2').link(...linkArgs);
-              expect(parentFn).to.have.been.calledWith(...linkArgs);
-              expect(childFn).to.have.been.calledWith(...linkArgs);
-            });
-
-          });
-
-          describe(`validateOptions functions`, () => {
-            let options, parentFn, childFn;
-            beforeEach(() => {
-              options = {
-                data: {
-                  a: 'b',
-                  c: {d: 'e'}
-                }
-              };
-              parentFn = sinon.spy();
-              childFn = sinon.spy();
-            });
-
-            it(`should call the parent validateOptions function when there is no child function`, () => {
-              setterFn([
-                {name, template, validateOptions: parentFn},
-                {name: 'type2', extends: name}
-              ]);
-              getterFn('type2').validateOptions(options);
-              expect(parentFn).to.have.been.calledWith(options);
-            });
-
-            it(`should call the child validateOptions function when there is no parent function`, () => {
-              setterFn([
-                {name, template},
-                {name: 'type2', extends: name, validateOptions: childFn}
-              ]);
-              getterFn('type2').validateOptions(options);
-              expect(childFn).to.have.been.calledWith(options);
-            });
-
-            it(`should call the child validateOptions function and the parent validateOptions function when they are both present`, () => {
-              setterFn([
-                {name, template, validateOptions: parentFn},
-                {name: 'type2', extends: name, validateOptions: childFn}
-              ]);
-              getterFn('type2').validateOptions(options);
-              expect(childFn).to.have.been.calledWith(options);
-              expect(parentFn).to.have.been.calledWith(options);
-            });
-
-            it(`should pass the result of the child's defaultOptions with the given options to the parent's validateOptions function`, () => {
-              const defaultOptions = {data: {f: 'g'}};
-              const combinedOptions = {data: {a: 'b', c: {d: 'e'}, f: 'g'}};
-              setterFn([
-                {name, template, validateOptions: parentFn},
-                {name: 'type2', extends: name, validateOptions: childFn, defaultOptions}
-              ]);
-              getterFn('type2').validateOptions(options);
-              expect(childFn).to.have.been.calledWith(options);
-              expect(parentFn).to.have.been.calledWith(combinedOptions);
-            });
-          });
-
-          describe(`controller functions`, () => {
-            let parentFn, childFn, $controller, $scope;
-            beforeEach(inject(($rootScope, _$controller_) => {
-              $scope = $rootScope.$new();
-              $controller = _$controller_;
-              parentFn = sinon.spy();
-              parentFn.$inject = ['$log'];
-              childFn = sinon.spy();
-              childFn.$inject = ['$http'];
-            }));
-
-            it(`should call the parent controller function when there is no child controller function`, inject(($log) => {
-              setterFn([
-                {name, template, controller: parentFn},
-                {name: 'type2', extends: name}
-              ]);
-              $controller(getterFn('type2').controller, {$scope});
-              expect(parentFn).to.have.been.calledWith($log);
-            }));
-
-            it(`should call the parent controller function and the child's when there is a child controller function`, inject(($log, $http) => {
-              setterFn([
-                {name, template, controller: parentFn},
-                {name: 'type2', extends: name, controller: childFn}
-              ]);
-              $controller(getterFn('type2').controller, {$scope});
-              expect(parentFn).to.have.been.calledWith($log);
-              expect(childFn).to.have.been.calledWith($http);
-            }));
-
-            it(`should call the child controller function when there's no parent controller`, inject(($http) => {
-              setterFn([
-                {name, template},
-                {name: 'type2', extends: name, controller: childFn}
-              ]);
-              $controller(getterFn('type2').controller, {$scope});
-              expect(childFn).to.have.been.calledWith($http);
-            }));
-
-          });
-        });
-
-        describe(`validateOptions`, () => {
-          it(`should allow you to specify this as a property of a type`, () => {
-            const validateOptions = () => {
-            };
-            expect(() => {
-              setterFn({
-                name,
-                validateOptions,
-                template
-              });
-            }).to.not.throw();
-            expect(getterFn(name).validateOptions).to.be.a('function');
-          });
-        });
-
-      });
-
-      describe('(◞‸◟；) path', () => {
-        it('should throw an error when the first argument is not an object or an array', () => {
-          expect(() => setterFn('string')).to.throw(/must.*provide.*object.*array/);
-          expect(() => setterFn(324)).to.throw(/must.*provide.*object.*array/);
-          expect(() => setterFn(false)).to.throw(/must.*provide.*object.*array/);
-        });
-
-        it('should throw an error when a name is not provided', () => {
-          expect(() => setterFn({templateUrl})).to.throw(/formlyConfig\.setType/);
-        });
-
-        it(`should throw an error when specifying both a template and a templateUrl`, () => {
-          expect(() => setterFn({name, template, templateUrl})).to.throw(/formlyConfig\.setType/);
-        });
-
-        it(`should throw an error when an extra property is provided`, () => {
-          expect(() => setterFn({name, templateUrl, extra: true})).to.throw(/formlyConfig\.setType/);
-        });
-
-        it('should warn when attempting to override a type', () => {
-          shouldWarn(/overwrite/, function() {
-            setterFn({name, template});
-            setterFn({name, template});
-          });
-        });
-      });
-
-      describe(`apiCheck`, () => {
-        testApiCheck('setType', 'getType');
       });
     });
 
-    function testApiCheck(setterName, getterName) {
-      const template = 'something with <formly-transclude></formly-transclude>';
-      const name = 'input';
-      let setterFn, getterFn, formlyApiCheck;
-      beforeEach(inject((_formlyApiCheck_, formlyConfig) => {
-        formlyApiCheck = _formlyApiCheck_;
-        setterFn = formlyConfig[setterName];
-        getterFn = formlyConfig[getterName];
-      }));
-      it(`should allow you to specify an apiCheck function that will be used to validate your options`, () => {
-        const apiCheck = {
+    describe('(◞‸◟；) path', () => {
+      it('should throw an error when providing both a template and templateUrl', () => {
+        expect(() => setterFn({template, templateUrl}, name)).to.throw(/template.*?only if templateUrl.*not/i);
+      });
+
+      it('should throw an error when providing neither a template or a templateUrl', () => {
+        expect(() => setterFn({
+          template,
+          templateUrl
+        }, name)).to.throw(/template.*specified only if templateUrl is not specified/i);
+      });
+
+      it('should throw an error when the template does not use formly-transclude', () => {
+        var error = /templates.*?must.*?<formly-transclude><\/formly-transclude>/;
+        expect(() => setterFn({template: 'no formly-transclude'})).to.throw(error);
+      });
+
+      it('should throw an error when specifying an array type where not all items are strings', () => {
+        var error = /types.*?typeOrArrayOf.*?String.*?/i;
+        expect(() => setterFn({template, types: ['hi', 2, false, 'cool']})).to.throw(error);
+      });
+
+      it('should warn when attempting to override a template wrapper', () => {
+        shouldWarn(/overwrite/, function() {
+          setterFn({template});
+          setterFn({template});
+        });
+      });
+
+      it('should not warn when attempting to override a template wrapper if overwriteOk is true', () => {
+        shouldNotWarn(() => {
+          setterFn({template});
+          setterFn({template, overwriteOk: true});
+        });
+      });
+    });
+
+
+    describe(`apiCheck`, () => {
+      testApiCheck('setWrapper', 'getWrapper');
+    });
+
+  });
+
+  describe('getWrapperByType', () => {
+    var getterFn, setterFn;
+    var types = ['input', 'checkbox'];
+    var types2 = ['input', 'select'];
+    var templateUrl = '/path/to/file.html';
+    beforeEach(inject(function(formlyConfig) {
+      setterFn = formlyConfig.setWrapper;
+      getterFn = formlyConfig.getWrapperByType;
+    }));
+
+    describe('＼(＾O＾)／ path', () => {
+      it('should return a template wrapper that has the same type', () => {
+        var option = setterFn({templateUrl, types});
+        expect(getterFn(types[0])).to.eql([option]);
+      });
+
+      it('should return an array when multiple wrappers have the same time', () => {
+        setterFn({templateUrl, types});
+        setterFn({templateUrl, types: types2});
+        var inputWrappers = getterFn('input');
+        expect(inputWrappers).to.be.instanceOf(Array);
+        expect(inputWrappers).to.have.length(2);
+      });
+
+    });
+  });
+
+  describe('removeWrapper', () => {
+    var remove, removeForType, setterFn, getterFn, getByTypeFn;
+    var template = '<div>Something <formly-transclude></formly-transclude> cool</div>';
+    var name = 'name';
+    var types = ['input', 'checkbox'];
+    var types2 = ['input', 'something else'];
+    var types3 = ['checkbox', 'something else'];
+    beforeEach(inject((formlyConfig) => {
+      remove = formlyConfig.removeWrapperByName;
+      removeForType = formlyConfig.removeWrappersForType;
+      setterFn = formlyConfig.setWrapper;
+      getterFn = formlyConfig.getWrapper;
+      getByTypeFn = formlyConfig.getWrapperByType;
+    }));
+
+    it('should allow you to remove a wrapper', () => {
+      setterFn(template, name);
+      remove(name);
+      expect(getterFn(name)).to.be.empty;
+    });
+
+    it('should allow you to remove a wrapper for a type', () => {
+      setterFn({types, template});
+      setterFn({types: types2, template});
+      var checkboxAndSomethingElseWrapper = setterFn({types: types3, template});
+      removeForType('input');
+      expect(getByTypeFn('input')).to.be.empty;
+      var checkboxWrappers = getByTypeFn('checkbox');
+      expect(checkboxWrappers).to.eql([checkboxAndSomethingElseWrapper]);
+    });
+  });
+
+
+  describe('setType/getType', () => {
+    var getterFn, setterFn;
+    var name = 'input';
+    var template = '<input type="{{options.inputType}}" />';
+    var templateUrl = '/input.html';
+    var wrapper = 'input';
+    var wrapper2 = 'input2';
+    beforeEach(inject(function(formlyConfig) {
+      getterFn = formlyConfig.getType;
+      setterFn = formlyConfig.setType;
+    }));
+
+    describe('＼(＾O＾)／ path', () => {
+      it('should accept an object with a name and a template', () => {
+        setterFn({name, template});
+        expect(getterFn(name).template).to.equal(template);
+      });
+
+      it('should accept an object with a name and a templateUrl', () => {
+        setterFn({name, templateUrl});
+        expect(getterFn(name).templateUrl).to.equal(templateUrl);
+      });
+
+      it('should accept an array of objects', () => {
+        setterFn([
+          {name, template},
+          {name: 'type2', templateUrl}
+        ]);
+        expect(getterFn(name).template).to.equal(template);
+        expect(getterFn('type2').templateUrl).to.equal(templateUrl);
+      });
+
+      it('should allow you to set a wrapper as a string', () => {
+        setterFn({name, template, wrapper});
+        expect(getterFn(name).wrapper).to.equal(wrapper);
+      });
+
+      it('should allow you to set a wrapper as an array', () => {
+        setterFn({name, template, wrapper: [wrapper, wrapper2]});
+        expect(getterFn(name).wrapper).to.eql([wrapper, wrapper2]);
+      });
+
+      describe(`extends`, () => {
+        describe(`object case`, () => {
+          beforeEach(() => {
+            setterFn([
+              {
+                name,
+                template,
+                defaultOptions: {
+                  templateOptions: {
+                    required: true,
+                    min: 3
+                  }
+                }
+              },
+              {
+                name: 'type2',
+                extends: name,
+                defaultOptions: {
+                  templateOptions: {
+                    required: false,
+                    max: 4
+                  },
+                  data: {
+                    extraStuff: [1, 2, 3]
+                  }
+                }
+              }
+            ]);
+          });
+          it(`should inherit all fields that it does not have itself`, () => {
+            expect(getterFn('type2').template).to.eql(template);
+          });
+
+          it(`should merge objects that it shares`, () => {
+            expect(getterFn('type2').defaultOptions).to.eql({
+              templateOptions: {
+                required: false,
+                min: 3,
+                max: 4
+              },
+              data: {
+                extraStuff: [1, 2, 3]
+              }
+            });
+          });
+
+          it(`should not error when extends is specified without a template, templateUrl, or defaultOptions`, () => {
+            expect(() => setterFn({name: 'type3', extends: 'type2'})).to.not.throw();
+          });
+
+        });
+
+        describe(`function cases`, () => {
+          let args, parentFn, childFn, parentDefaultOptions, childDefaultOptions,
+            argsAndParent;
+          beforeEach(() => {
+            args = {data: {someData: true}};
+            parentDefaultOptions = {
+              data: {extraOptions: true},
+              templateOptions: {placeholder: 'hi'}
+            };
+            childDefaultOptions = {
+              templateOptions: {placeholder: 'hey', required: true}
+            };
+            parentFn = sinon.stub().returns(parentDefaultOptions);
+            childFn = sinon.stub().returns(childDefaultOptions);
+            argsAndParent = {
+              data: {someData: true, extraOptions: true},
+              templateOptions: {placeholder: 'hi'}
+            };
+          });
+
+          it(`should call the extended parent's defaultOptions function and its own defaultOptions function`, () => {
+            setterFn([
+              {name, defaultOptions: parentFn},
+              {name: 'type2', extends: name, defaultOptions: childFn}
+            ]);
+            getterFn('type2').defaultOptions(args);
+            expect(parentFn).to.have.been.calledWith(args);
+            expect(childFn).to.have.been.calledWith(argsAndParent);
+          });
+
+          it(`should call the extended parent's defaultOptions function when it doesn't have one of its own`, () => {
+            setterFn([
+              {name, defaultOptions: parentFn},
+              {name: 'type2', extends: name}
+            ]);
+            getterFn('type2').defaultOptions(args);
+            expect(parentFn).to.have.been.calledWith(args);
+          });
+
+          it(`should call its own defaultOptions function when the parent doesn't have one`, () => {
+            setterFn([
+              {name, template},
+              {name: 'type2', extends: name, defaultOptions: childFn}
+            ]);
+            getterFn('type2').defaultOptions(args);
+            expect(childFn).to.have.been.calledWith(args);
+          });
+
+          it(`should extend its defaultOptions object with the parent's defaultOptions object`, () => {
+            const objectMergedDefaultOptions = {
+              data: {extraOptions: true},
+              templateOptions: {placeholder: 'hey', required: true}
+            };
+            setterFn([
+              {name, defaultOptions: parentDefaultOptions},
+              {name: 'type2', extends: name, defaultOptions: childDefaultOptions}
+            ]);
+            expect(getterFn('type2').defaultOptions).to.eql(objectMergedDefaultOptions);
+          });
+
+          it(`should call its defaultOptions with the parent's defaultOptions object merged with the given args`, () => {
+            setterFn([
+              {name, defaultOptions: parentDefaultOptions},
+              {name: 'type2', extends: name, defaultOptions: childFn}
+            ]);
+            var returned = getterFn('type2').defaultOptions(args);
+            expect(childFn).to.have.been.calledWith(argsAndParent);
+            expect(returned).to.eql(childDefaultOptions);
+          });
+        });
+
+        describe(`link functions`, () => {
+          let linkArgs, parentFn, childFn;
+          beforeEach(inject(($rootScope) => {
+            linkArgs = [$rootScope.$new(), angular.element('<div></div>'), {}];
+            parentFn = sinon.spy();
+            childFn = sinon.spy();
+          }));
+
+          it(`should call the parent link function when there is no child function`, () => {
+            setterFn([
+              {name, template, link: parentFn},
+              {name: 'type2', extends: name}
+            ]);
+            getterFn('type2').link(...linkArgs);
+            expect(parentFn).to.have.been.calledWith(...linkArgs);
+          });
+
+          it(`should call the child link function when there is no parent function`, () => {
+            setterFn([
+              {name, template},
+              {name: 'type2', extends: name, link: childFn}
+            ]);
+            getterFn('type2').link(...linkArgs);
+            expect(childFn).to.have.been.calledWith(...linkArgs);
+          });
+
+          it(`should call the child link function and the parent link function when they are both present`, () => {
+            setterFn([
+              {name, template, link: parentFn},
+              {name: 'type2', extends: name, link: childFn}
+            ]);
+            getterFn('type2').link(...linkArgs);
+            expect(parentFn).to.have.been.calledWith(...linkArgs);
+            expect(childFn).to.have.been.calledWith(...linkArgs);
+          });
+
+        });
+
+        describe(`validateOptions functions`, () => {
+          let options, parentFn, childFn;
+          beforeEach(() => {
+            options = {
+              data: {
+                a: 'b',
+                c: {d: 'e'}
+              }
+            };
+            parentFn = sinon.spy();
+            childFn = sinon.spy();
+          });
+
+          it(`should call the parent validateOptions function when there is no child function`, () => {
+            setterFn([
+              {name, template, validateOptions: parentFn},
+              {name: 'type2', extends: name}
+            ]);
+            getterFn('type2').validateOptions(options);
+            expect(parentFn).to.have.been.calledWith(options);
+          });
+
+          it(`should call the child validateOptions function when there is no parent function`, () => {
+            setterFn([
+              {name, template},
+              {name: 'type2', extends: name, validateOptions: childFn}
+            ]);
+            getterFn('type2').validateOptions(options);
+            expect(childFn).to.have.been.calledWith(options);
+          });
+
+          it(`should call the child validateOptions function and the parent validateOptions function when they are both present`, () => {
+            setterFn([
+              {name, template, validateOptions: parentFn},
+              {name: 'type2', extends: name, validateOptions: childFn}
+            ]);
+            getterFn('type2').validateOptions(options);
+            expect(childFn).to.have.been.calledWith(options);
+            expect(parentFn).to.have.been.calledWith(options);
+          });
+
+          it(`should pass the result of the child's defaultOptions with the given options to the parent's validateOptions function`, () => {
+            const defaultOptions = {data: {f: 'g'}};
+            const combinedOptions = {data: {a: 'b', c: {d: 'e'}, f: 'g'}};
+            setterFn([
+              {name, template, validateOptions: parentFn},
+              {name: 'type2', extends: name, validateOptions: childFn, defaultOptions}
+            ]);
+            getterFn('type2').validateOptions(options);
+            expect(childFn).to.have.been.calledWith(options);
+            expect(parentFn).to.have.been.calledWith(combinedOptions);
+          });
+        });
+
+        describe(`controller functions`, () => {
+          let parentFn, childFn, $controller, $scope;
+          beforeEach(inject(($rootScope, _$controller_) => {
+            $scope = $rootScope.$new();
+            $controller = _$controller_;
+            parentFn = sinon.spy();
+            parentFn.$inject = ['$log'];
+            childFn = sinon.spy();
+            childFn.$inject = ['$http'];
+          }));
+
+          it(`should call the parent controller function when there is no child controller function`, inject(($log) => {
+            setterFn([
+              {name, template, controller: parentFn},
+              {name: 'type2', extends: name}
+            ]);
+            $controller(getterFn('type2').controller, {$scope});
+            expect(parentFn).to.have.been.calledWith($log);
+          }));
+
+          it(`should call the parent controller function and the child's when there is a child controller function`, inject(($log, $http) => {
+            setterFn([
+              {name, template, controller: parentFn},
+              {name: 'type2', extends: name, controller: childFn}
+            ]);
+            $controller(getterFn('type2').controller, {$scope});
+            expect(parentFn).to.have.been.calledWith($log);
+            expect(childFn).to.have.been.calledWith($http);
+          }));
+
+          it(`should call the child controller function when there's no parent controller`, inject(($http) => {
+            setterFn([
+              {name, template},
+              {name: 'type2', extends: name, controller: childFn}
+            ]);
+            $controller(getterFn('type2').controller, {$scope});
+            expect(childFn).to.have.been.calledWith($http);
+          }));
+
+        });
+      });
+
+      describe(`validateOptions`, () => {
+        it(`should allow you to specify this as a property of a type`, () => {
+          const validateOptions = () => {
+          };
+          expect(() => {
+            setterFn({
+              name,
+              validateOptions,
+              template
+            });
+          }).to.not.throw();
+          expect(getterFn(name).validateOptions).to.be.a('function');
+        });
+      });
+
+    });
+
+    describe('(◞‸◟；) path', () => {
+      it('should throw an error when the first argument is not an object or an array', () => {
+        expect(() => setterFn('string')).to.throw(/must.*provide.*object.*array/);
+        expect(() => setterFn(324)).to.throw(/must.*provide.*object.*array/);
+        expect(() => setterFn(false)).to.throw(/must.*provide.*object.*array/);
+      });
+
+      it('should throw an error when a name is not provided', () => {
+        expect(() => setterFn({templateUrl})).to.throw(/formlyConfig\.setType/);
+      });
+
+      it(`should throw an error when specifying both a template and a templateUrl`, () => {
+        expect(() => setterFn({name, template, templateUrl})).to.throw(/formlyConfig\.setType/);
+      });
+
+      it(`should throw an error when an extra property is provided`, () => {
+        expect(() => setterFn({name, templateUrl, extra: true})).to.throw(/formlyConfig\.setType/);
+      });
+
+      it('should warn when attempting to override a type', () => {
+        shouldWarn(/overwrite/, function() {
+          setterFn({name, template});
+          setterFn({name, template});
+        });
+      });
+    });
+
+    describe(`apiCheck`, () => {
+      testApiCheck('setType', 'getType');
+    });
+  });
+
+  function testApiCheck(setterName, getterName) {
+    const template = 'something with <formly-transclude></formly-transclude>';
+    const name = 'input';
+    let setterFn, getterFn, formlyApiCheck;
+    beforeEach(inject((_formlyApiCheck_, formlyConfig) => {
+      formlyApiCheck = _formlyApiCheck_;
+      setterFn = formlyConfig[setterName];
+      getterFn = formlyConfig[getterName];
+    }));
+    it(`should allow you to specify an apiCheck function that will be used to validate your options`, () => {
+      const apiCheck = {
+        templateOptions: formlyApiCheck.shape({}),
+        data: formlyApiCheck.shape({})
+      };
+      expect(() => {
+        setterFn({
+          name,
+          apiCheck,
+          template
+        });
+      }).to.not.throw();
+
+      expect(getterFn(name).apiCheck).to.equal(apiCheck);
+    });
+
+    it(`should throw an error when specifying a function is the wrong shape`, () => {
+      // TODO
+    });
+
+    describe(`apiCheckInstance`, () => {
+      let apiCheckInstance;
+      let apiCheck;
+      beforeEach(() => {
+        apiCheckInstance = require('api-check')();
+        apiCheck = {
           templateOptions: formlyApiCheck.shape({}),
           data: formlyApiCheck.shape({})
         };
+      });
+      it(`should allow you to specify an instance of your own apiCheck so messaging will be custom`, () => {
         expect(() => {
-          setterFn({
-            name,
-            apiCheck,
-            template
-          });
+          setterFn({name, apiCheck, apiCheckInstance, template});
         }).to.not.throw();
+        expect(getterFn(name).apiCheckInstance).to.equal(apiCheckInstance);
+      });
+      it(`should throw an error if you specify an instance without specifying an apiCheck`, () => {
+        expect(() => {
+          setterFn({name, apiCheckInstance, template});
+        }).to.throw();
+      });
+    });
 
-        expect(getterFn(name).apiCheck).to.equal(apiCheck);
+    describe(`apiCheckFunction`, () => {
+      let apiCheck;
+      beforeEach(() => {
+        apiCheck = {
+          templateOptions: formlyApiCheck.shape({}),
+          data: formlyApiCheck.shape({})
+        };
+      });
+      it(`should allow you to specify warn or throw as the `, () => {
+        expect(() => {
+          setterFn({name, apiCheck, apiCheckFunction: 'warn', template});
+        }).to.not.throw();
+        expect(getterFn(name).apiCheckFunction).to.equal('warn');
+        expect(() => {
+          setterFn({name: 'name2', apiCheck, apiCheckFunction: 'throw', template});
+        }).to.not.throw();
+        expect(getterFn('name2').apiCheckFunction).to.equal('throw');
       });
 
-      it(`should throw an error when specifying a function is the wrong shape`, () => {
-        // TODO
+      it(`should throw an error if you specify anything other than warn or throw`, () => {
+        expect(() => {
+          setterFn({name, apiCheckFunction: 'other', template});
+        }).to.throw();
       });
-
-      describe(`apiCheckInstance`, () => {
-        let apiCheckInstance;
-        let apiCheck;
-        beforeEach(() => {
-          apiCheckInstance = require('api-check')();
-          apiCheck = {
-            templateOptions: formlyApiCheck.shape({}),
-            data: formlyApiCheck.shape({})
-          };
-        });
-        it(`should allow you to specify an instance of your own apiCheck so messaging will be custom`, () => {
-          expect(() => {
-            setterFn({name, apiCheck, apiCheckInstance, template});
-          }).to.not.throw();
-          expect(getterFn(name).apiCheckInstance).to.equal(apiCheckInstance);
-        });
-        it(`should throw an error if you specify an instance without specifying an apiCheck`, () => {
-          expect(() => {
-            setterFn({name, apiCheckInstance, template});
-          }).to.throw();
-        });
-      });
-
-      describe(`apiCheckFunction`, () => {
-        let apiCheck;
-        beforeEach(() => {
-          apiCheck = {
-            templateOptions: formlyApiCheck.shape({}),
-            data: formlyApiCheck.shape({})
-          };
-        });
-        it(`should allow you to specify warn or throw as the `, () => {
-          expect(() => {
-            setterFn({name, apiCheck, apiCheckFunction: 'warn', template});
-          }).to.not.throw();
-          expect(getterFn(name).apiCheckFunction).to.equal('warn');
-          expect(() => {
-            setterFn({name: 'name2', apiCheck, apiCheckFunction: 'throw', template});
-          }).to.not.throw();
-          expect(getterFn('name2').apiCheckFunction).to.equal('throw');
-        });
-
-        it(`should throw an error if you specify anything other than warn or throw`, () => {
-          expect(() => {
-            setterFn({name, apiCheckFunction: 'other', template});
-          }).to.throw();
-        });
-      });
-    }
+    });
+  }
 
 
-    function shouldWarn(match, test) {
-      var originalWarn = console.warn;
-      var calledArgs;
-      console.warn = function() {
-        calledArgs = arguments;
-      };
-      test();
-      expect(calledArgs[0]).to.match(match);
-      console.warn = originalWarn;
-    }
+  function shouldWarn(match, test) {
+    var originalWarn = console.warn;
+    var calledArgs;
+    console.warn = function() {
+      calledArgs = arguments;
+    };
+    test();
+    expect(calledArgs[0]).to.match(match);
+    console.warn = originalWarn;
+  }
 
-    function shouldNotWarn(test) {
-      var originalWarn = console.warn;
-      var callCount = 0;
-      console.warn = () => callCount++;
-      test();
-      expect(callCount).to.equal(0);
-      console.warn = originalWarn;
-    }
-  });
-};
+  function shouldNotWarn(test) {
+    var originalWarn = console.warn;
+    var callCount = 0;
+    console.warn = () => callCount++;
+    test();
+    expect(callCount).to.equal(0);
+    console.warn = originalWarn;
+  }
+});

--- a/src/providers/formlyConfig.test.js
+++ b/src/providers/formlyConfig.test.js
@@ -1,5 +1,6 @@
 /* jshint maxlen:false */
 import sinon from 'sinon';
+import {expect} from 'chai';
 
 describe('formlyConfig', () => {
   beforeEach(window.module('formly'));

--- a/src/providers/formlyErrorAndWarningsUrlPrefix.js
+++ b/src/providers/formlyErrorAndWarningsUrlPrefix.js
@@ -1,2 +1,1 @@
-const prefix = `https://github.com/formly-js/angular-formly/blob/${VERSION}/other/ERRORS_AND_WARNINGS.md#`;
-export default prefix;
+export default `https://github.com/formly-js/angular-formly/blob/${VERSION}/other/ERRORS_AND_WARNINGS.md#`;

--- a/src/providers/formlyErrorAndWarningsUrlPrefix.js
+++ b/src/providers/formlyErrorAndWarningsUrlPrefix.js
@@ -1,6 +1,2 @@
-module.exports = ngModule => {
-  ngModule.constant(
-    'formlyErrorAndWarningsUrlPrefix',
-    `https://github.com/formly-js/angular-formly/blob/${VERSION}/other/ERRORS_AND_WARNINGS.md#`
-  );
-};
+const prefix = `https://github.com/formly-js/angular-formly/blob/${VERSION}/other/ERRORS_AND_WARNINGS.md#`;
+export default prefix;

--- a/src/providers/formlyUsability.js
+++ b/src/providers/formlyUsability.js
@@ -1,58 +1,57 @@
-var angular = require('angular-fix');
+import angular from 'angular-fix';
 
-module.exports = ngModule => {
-  ngModule.provider('formlyUsability', function(formlyVersion, formlyApiCheck) {
-    var errorsAndWarningsUrlPrefix =
-      `https://github.com/formly-js/angular-formly/blob/${formlyVersion}/other/ERRORS_AND_WARNINGS.md#`;
-    angular.extend(this, {
-      getFormlyError: getFormlyError,
-      getFieldError: getFieldError,
-      checkWrapper: checkWrapper,
-      checkWrapperTemplate: checkWrapperTemplate,
-      $get: () => this
-    });
-
-    function getFieldError(errorInfoSlug, message, field) {
-      if (arguments.length < 3) {
-        field = message;
-        message = errorInfoSlug;
-        errorInfoSlug = null;
-      }
-      return new Error(getErrorMessage(errorInfoSlug, message) + ` Field definition: ${angular.toJson(field)}`);
-    }
-
-    function getFormlyError(errorInfoSlug, message) {
-      if (!message) {
-        message = errorInfoSlug;
-        errorInfoSlug = null;
-      }
-      return new Error(getErrorMessage(errorInfoSlug, message));
-    }
-
-    function getErrorMessage(errorInfoSlug, message) {
-      let url = '';
-      if (errorInfoSlug !== null) {
-        url = `${errorsAndWarningsUrlPrefix}${errorInfoSlug}`;
-      }
-      return `Formly Error: ${message}. ${url}`;
-    }
-
-    function checkWrapper(wrapper) {
-      formlyApiCheck.throw(formlyApiCheck.formlyWrapperType, wrapper, {
-        prefix: 'formlyConfig.setWrapper',
-        urlSuffix: 'setwrapper-validation-failed'
-      });
-    }
-
-    function checkWrapperTemplate(template, additionalInfo) {
-      var formlyTransclude = '<formly-transclude></formly-transclude>';
-      if (template.indexOf(formlyTransclude) === -1) {
-        throw getFormlyError(
-          `Template wrapper templates must use "${formlyTransclude}" somewhere in them. ` +
-          `This one does not have "<formly-transclude></formly-transclude>" in it: ${template}` + '\n' +
-          `Additional information: ${JSON.stringify(additionalInfo)}`
-        );
-      }
-    }
+function formlyUsability (formlyVersion, formlyApiCheck) {
+  var errorsAndWarningsUrlPrefix =
+    `https://github.com/formly-js/angular-formly/blob/${formlyVersion}/other/ERRORS_AND_WARNINGS.md#`;
+  angular.extend(this, {
+    getFormlyError: getFormlyError,
+    getFieldError: getFieldError,
+    checkWrapper: checkWrapper,
+    checkWrapperTemplate: checkWrapperTemplate,
+    $get: () => this
   });
-};
+
+  function getFieldError(errorInfoSlug, message, field) {
+    if (arguments.length < 3) {
+      field = message;
+      message = errorInfoSlug;
+      errorInfoSlug = null;
+    }
+    return new Error(getErrorMessage(errorInfoSlug, message) + ` Field definition: ${angular.toJson(field)}`);
+  }
+
+  function getFormlyError(errorInfoSlug, message) {
+    if (!message) {
+      message = errorInfoSlug;
+      errorInfoSlug = null;
+    }
+    return new Error(getErrorMessage(errorInfoSlug, message));
+  }
+
+  function getErrorMessage(errorInfoSlug, message) {
+    let url = '';
+    if (errorInfoSlug !== null) {
+      url = `${errorsAndWarningsUrlPrefix}${errorInfoSlug}`;
+    }
+    return `Formly Error: ${message}. ${url}`;
+  }
+
+  function checkWrapper(wrapper) {
+    formlyApiCheck.throw(formlyApiCheck.formlyWrapperType, wrapper, {
+      prefix: 'formlyConfig.setWrapper',
+      urlSuffix: 'setwrapper-validation-failed'
+    });
+  }
+
+  function checkWrapperTemplate(template, additionalInfo) {
+    var formlyTransclude = '<formly-transclude></formly-transclude>';
+    if (template.indexOf(formlyTransclude) === -1) {
+      throw getFormlyError(
+        `Template wrapper templates must use "${formlyTransclude}" somewhere in them. ` +
+        `This one does not have "<formly-transclude></formly-transclude>" in it: ${template}` + '\n' +
+        `Additional information: ${JSON.stringify(additionalInfo)}`
+      );
+    }
+  }
+}
+export default formlyUsability;

--- a/src/providers/formlyUsability.js
+++ b/src/providers/formlyUsability.js
@@ -1,6 +1,6 @@
 import angular from 'angular-fix';
 
-function formlyUsability (formlyVersion, formlyApiCheck) {
+export default function formlyUsability (formlyVersion, formlyApiCheck) {
   var errorsAndWarningsUrlPrefix =
     `https://github.com/formly-js/angular-formly/blob/${formlyVersion}/other/ERRORS_AND_WARNINGS.md#`;
   angular.extend(this, {
@@ -54,4 +54,3 @@ function formlyUsability (formlyVersion, formlyApiCheck) {
     }
   }
 }
-export default formlyUsability;

--- a/src/providers/formlyValidationMessages.js
+++ b/src/providers/formlyValidationMessages.js
@@ -1,31 +1,29 @@
-module.exports = ngModule => {
-  ngModule.factory('formlyValidationMessages', function() {
+export default function () {
 
-    var formlyValidationMessages = {
-      addTemplateOptionValueMessage,
-      addStringMessage,
-      messages: {}
+  var formlyValidationMessages = {
+    addTemplateOptionValueMessage,
+    addStringMessage,
+    messages: {}
+  };
+
+  return formlyValidationMessages;
+
+  function addTemplateOptionValueMessage(name, prop, prefix, suffix, alternate) {
+    formlyValidationMessages.messages[name] = templateOptionValue(prop, prefix, suffix, alternate);
+  }
+
+  function addStringMessage(name, string) {
+    formlyValidationMessages.messages[name] = () => string;
+  }
+
+
+  function templateOptionValue(prop, prefix, suffix, alternate) {
+    return function getValidationMessage(viewValue, modelValue, scope) {
+      if (scope.options.templateOptions[prop]) {
+        return `${prefix} ${scope.options.templateOptions[prop]} ${suffix}`;
+      } else {
+        return alternate;
+      }
     };
-
-    return formlyValidationMessages;
-
-    function addTemplateOptionValueMessage(name, prop, prefix, suffix, alternate) {
-      formlyValidationMessages.messages[name] = templateOptionValue(prop, prefix, suffix, alternate);
-    }
-
-    function addStringMessage(name, string) {
-      formlyValidationMessages.messages[name] = () => string;
-    }
-
-
-    function templateOptionValue(prop, prefix, suffix, alternate) {
-      return function getValidationMessage(viewValue, modelValue, scope) {
-        if (scope.options.templateOptions[prop]) {
-          return `${prefix} ${scope.options.templateOptions[prop]} ${suffix}`;
-        } else {
-          return alternate;
-        }
-      };
-    }
-  });
-};
+  }
+}

--- a/src/providers/formlyValidationMessages.js
+++ b/src/providers/formlyValidationMessages.js
@@ -1,19 +1,19 @@
-export default function () {
+export default function formlyValidationMessages () {
 
-  var formlyValidationMessages = {
+  var validationMessages = {
     addTemplateOptionValueMessage,
     addStringMessage,
     messages: {}
   };
 
-  return formlyValidationMessages;
+  return validationMessages;
 
   function addTemplateOptionValueMessage(name, prop, prefix, suffix, alternate) {
-    formlyValidationMessages.messages[name] = templateOptionValue(prop, prefix, suffix, alternate);
+    validationMessages.messages[name] = templateOptionValue(prop, prefix, suffix, alternate);
   }
 
   function addStringMessage(name, string) {
-    formlyValidationMessages.messages[name] = () => string;
+    validationMessages.messages[name] = () => string;
   }
 
 

--- a/src/providers/formlyVersion.js
+++ b/src/providers/formlyVersion.js
@@ -1,3 +1,1 @@
-module.exports = ngModule => {
-  ngModule.constant('formlyVersion', VERSION);
-};
+export default VERSION;

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -1,8 +1,0 @@
-module.exports = ngModule => {
-  require('./formlyApiCheck')(ngModule);
-  require('./formlyUsability')(ngModule);
-  require('./formlyConfig')(ngModule);
-  require('./formlyVersion')(ngModule);
-  require('./formlyErrorAndWarningsUrlPrefix')(ngModule);
-  require('./formlyValidationMessages')(ngModule);
-};

--- a/src/run/formlyCustomTags.js
+++ b/src/run/formlyCustomTags.js
@@ -1,25 +1,23 @@
-module.exports = ngModule => {
-  ngModule.run(addCustomTags);
+function addCustomTags($document) {
 
-  function addCustomTags($document) {
+  if ($document && $document.get) {
+    //IE8 check ->
+    // http://stackoverflow.com/questions/10964966/detect-ie-version-prior-to-v9-in-javascript/10965203#10965203
+    var document = $document.get(0);
+    var div = document.createElement('div');
+    div.innerHTML = '<!--[if lt IE 9]><i></i><![endif]-->';
+    var isIeLessThan9 = (div.getElementsByTagName('i').length === 1);
 
-    if ($document && $document.get) {
-      //IE8 check ->
-      // http://stackoverflow.com/questions/10964966/detect-ie-version-prior-to-v9-in-javascript/10965203#10965203
-      var document = $document.get(0);
-      var div = document.createElement('div');
-      div.innerHTML = '<!--[if lt IE 9]><i></i><![endif]-->';
-      var isIeLessThan9 = (div.getElementsByTagName('i').length === 1);
+    if (isIeLessThan9) {
+      //add the custom elements that we need for formly
+      var customElements =
+        ['formly-field', 'formly-form', 'formly-custom-validation', 'formly-focus', 'formly-transpose'];
 
-      if (isIeLessThan9) {
-        //add the custom elements that we need for formly
-        var customElements =
-          ['formly-field', 'formly-form', 'formly-custom-validation', 'formly-focus', 'formly-transpose'];
-
-        for (var i = 0; i < customElements.length; i++) {
-          document.createElement(customElements[i]);
-        }
+      for (var i = 0; i < customElements.length; i++) {
+        document.createElement(customElements[i]);
       }
     }
   }
-};
+}
+
+export default addCustomTags;

--- a/src/run/formlyCustomTags.js
+++ b/src/run/formlyCustomTags.js
@@ -1,4 +1,4 @@
-function addCustomTags($document) {
+export default function addCustomTags($document) {
 
   if ($document && $document.get) {
     //IE8 check ->
@@ -19,5 +19,3 @@ function addCustomTags($document) {
     }
   }
 }
-
-export default addCustomTags;

--- a/src/run/formlyNgModelAttrsManipulator.js
+++ b/src/run/formlyNgModelAttrsManipulator.js
@@ -1,6 +1,6 @@
 import angular from 'angular-fix';
 
-function addFormlyNgModelAttrsManipulator(formlyConfig) {
+export default function addFormlyNgModelAttrsManipulator(formlyConfig) {
   if (formlyConfig.extras.disableNgModelAttrsManipulator) {
     return;
   }
@@ -172,5 +172,3 @@ function addFormlyNgModelAttrsManipulator(formlyConfig) {
     });
   }
 }
-
-export default addFormlyNgModelAttrsManipulator;

--- a/src/run/formlyNgModelAttrsManipulator.js
+++ b/src/run/formlyNgModelAttrsManipulator.js
@@ -1,180 +1,176 @@
-const angular = require('../angular-fix');
+import angular from 'angular-fix';
 
-module.exports = ngModule => {
-  ngModule.run(addFormlyNgModelAttrsManipulator);
+function addFormlyNgModelAttrsManipulator(formlyConfig) {
+  if (formlyConfig.extras.disableNgModelAttrsManipulator) {
+    return;
+  }
+  formlyConfig.templateManipulators.preWrapper.push(ngModelAttrsManipulator);
 
-  addFormlyNgModelAttrsManipulator.test = ON_TEST ? require('./formlyNgModelAttrsManipulator.test')(ngModule) : null;
 
-  function addFormlyNgModelAttrsManipulator(formlyConfig) {
-    if (formlyConfig.extras.disableNgModelAttrsManipulator) {
-      return;
+  function ngModelAttrsManipulator(template, options, scope) {
+    /* jshint maxcomplexity:6 */
+    var el = document.createElement('div');
+    var data = options.data;
+    if (data.skipNgModelAttrsManipulator === true) {
+      return template;
     }
-    formlyConfig.templateManipulators.preWrapper.push(ngModelAttrsManipulator);
+    el.innerHTML = template;
+    var modelNodes = el.querySelectorAll('[ng-model]');
+    if (!modelNodes || !modelNodes.length) {
+      return template;
+    }
+
+    addIfNotPresent(modelNodes, 'id', scope.id);
+    addIfNotPresent(modelNodes, 'name', scope.id);
+
+    addValidation();
+    addModelOptions();
+    addTemplateOptionsAttrs();
 
 
-    function ngModelAttrsManipulator(template, options, scope) {
-      /* jshint maxcomplexity:6 */
-      var el = document.createElement('div');
-      var data = options.data;
-      if (data.skipNgModelAttrsManipulator === true) {
-        return template;
+    return el.innerHTML;
+
+
+    function addValidation() {
+      if (angular.isDefined(options.validators) || angular.isDefined(options.validation.messages)) {
+        addIfNotPresent(modelNodes, 'formly-custom-validation', '');
       }
-      el.innerHTML = template;
-      var modelNodes = el.querySelectorAll('[ng-model]');
-      if (!modelNodes || !modelNodes.length) {
-        return template;
-      }
+    }
 
-      addIfNotPresent(modelNodes, 'id', scope.id);
-      addIfNotPresent(modelNodes, 'name', scope.id);
-
-      addValidation();
-      addModelOptions();
-      addTemplateOptionsAttrs();
-
-
-      return el.innerHTML;
-
-
-      function addValidation() {
-        if (angular.isDefined(options.validators) || angular.isDefined(options.validation.messages)) {
-          addIfNotPresent(modelNodes, 'formly-custom-validation', '');
+    function addModelOptions() {
+      if (angular.isDefined(options.modelOptions)) {
+        addIfNotPresent(modelNodes, 'ng-model-options', 'options.modelOptions');
+        if (options.modelOptions.getterSetter) {
+          angular.forEach(modelNodes, node => {
+            node.setAttribute('ng-model', 'options.value');
+          });
         }
       }
+    }
 
-      function addModelOptions() {
-        if (angular.isDefined(options.modelOptions)) {
-          addIfNotPresent(modelNodes, 'ng-model-options', 'options.modelOptions');
-          if (options.modelOptions.getterSetter) {
-            angular.forEach(modelNodes, node => {
-              node.setAttribute('ng-model', 'options.value');
-            });
+    function addTemplateOptionsAttrs() {
+      if (!options.templateOptions && !options.expressionProperties) {
+        // no need to run these if there are no templateOptions or expressionProperties
+        return;
+      }
+      const to = options.templateOptions || {};
+      const ep = options.expressionProperties || {};
+
+      let ngModelAttributes = getBuiltInAttributes();
+
+      // extend with the user's specifications winning
+      angular.extend(ngModelAttributes, options.ngModelAttrs);
+
+      // Feel free to make this more simple :-)
+      angular.forEach(ngModelAttributes, (val, name) => {
+        /* jshint maxcomplexity:14 */
+        let attrVal;
+        let attrName;
+        const ref = `options.templateOptions['${name}']`;
+        const toVal = to[name];
+        const epVal = getEpValue(ep, name);
+
+        const inTo = angular.isDefined(toVal);
+        const inEp = angular.isDefined(epVal);
+        if (val.value) {
+          // I realize this looks backwards, but it's right, trust me...
+          attrName = val.value;
+          attrVal = name;
+        } else if (val.expression && inTo) {
+          attrName = val.expression;
+          if (angular.isString(to[name])) {
+            attrVal = `$eval(${ref})`;
+          } else if (angular.isFunction(to[name])) {
+            attrVal = `${ref}(model[options.key], options, this, $event)`;
+          } else {
+            throw new Error(
+              `options.templateOptions.${name} must be a string or function: ${JSON.stringify(options)}`
+            );
           }
-        }
-      }
-
-      function addTemplateOptionsAttrs() {
-        if (!options.templateOptions && !options.expressionProperties) {
-          // no need to run these if there are no templateOptions or expressionProperties
-          return;
-        }
-        const to = options.templateOptions || {};
-        const ep = options.expressionProperties || {};
-
-        let ngModelAttributes = getBuiltInAttributes();
-
-        // extend with the user's specifications winning
-        angular.extend(ngModelAttributes, options.ngModelAttrs);
-
-        // Feel free to make this more simple :-)
-        angular.forEach(ngModelAttributes, (val, name) => {
-          /* jshint maxcomplexity:14 */
-          let attrVal;
-          let attrName;
-          const ref = `options.templateOptions['${name}']`;
-          const toVal = to[name];
-          const epVal = getEpValue(ep, name);
-
-          const inTo = angular.isDefined(toVal);
-          const inEp = angular.isDefined(epVal);
-          if (val.value) {
-            // I realize this looks backwards, but it's right, trust me...
-            attrName = val.value;
-            attrVal = name;
-          } else if (val.expression && inTo) {
-            attrName = val.expression;
-            if (angular.isString(to[name])) {
-              attrVal = `$eval(${ref})`;
-            } else if (angular.isFunction(to[name])) {
-              attrVal = `${ref}(model[options.key], options, this, $event)`;
-            } else {
-              throw new Error(
-                `options.templateOptions.${name} must be a string or function: ${JSON.stringify(options)}`
-              );
-            }
-          } else if (val.bound && inEp) {
-            attrName = val.bound;
-            attrVal = ref;
-          } else if ((val.attribute || val.boolean) && inEp) {
-            attrName = val.attribute || val.boolean;
-            attrVal = `{{${ref}}}`;
-          } else if (val.attribute && inTo) {
-            attrName = val.attribute;
-            attrVal = toVal;
-          } else if (val.boolean) {
-            if (inTo && !inEp && toVal) {
-              attrName = val.boolean;
-              attrVal = true;
-            } else {
-              // jshint -W035
-              // empty to illustrate that a boolean will not be added via val.bound
-              // if you want it added via val.bound, then put it in expressionProperties
-            }
-          } else if (val.bound && inTo) {
-            attrName = val.bound;
-            attrVal = ref;
+        } else if (val.bound && inEp) {
+          attrName = val.bound;
+          attrVal = ref;
+        } else if ((val.attribute || val.boolean) && inEp) {
+          attrName = val.attribute || val.boolean;
+          attrVal = `{{${ref}}}`;
+        } else if (val.attribute && inTo) {
+          attrName = val.attribute;
+          attrVal = toVal;
+        } else if (val.boolean) {
+          if (inTo && !inEp && toVal) {
+            attrName = val.boolean;
+            attrVal = true;
+          } else {
+            // jshint -W035
+            // empty to illustrate that a boolean will not be added via val.bound
+            // if you want it added via val.bound, then put it in expressionProperties
           }
-
-          if (angular.isDefined(attrName) && angular.isDefined(attrVal)) {
-            addIfNotPresent(modelNodes, attrName, attrVal);
-          }
-        });
-      }
-    }
-
-    // Utility functions
-    function getBuiltInAttributes() {
-      let ngModelAttributes = {
-        focus: {
-          attribute: 'formly-focus'
+        } else if (val.bound && inTo) {
+          attrName = val.bound;
+          attrVal = ref;
         }
-      };
-      const boundOnly = [];
-      const bothBooleanAndBound = ['required', 'disabled'];
-      const bothAttributeAndBound = ['pattern', 'minlength'];
-      const expressionOnly = ['change', 'keydown', 'keyup', 'keypress', 'click', 'focus', 'blur'];
-      const attributeOnly = ['placeholder', 'min', 'max', 'tabindex', 'type'];
-      if (formlyConfig.extras.ngModelAttrsManipulatorPreferUnbound) {
-        bothAttributeAndBound.push('maxlength');
-      } else {
-        boundOnly.push('maxlength');
-      }
 
-      angular.forEach(boundOnly, item => {
-        ngModelAttributes[item] = {bound: 'ng-' + item};
-      });
-
-      angular.forEach(bothBooleanAndBound, item => {
-        ngModelAttributes[item] = {boolean: item, bound: 'ng-' + item};
-      });
-
-      angular.forEach(bothAttributeAndBound, item => {
-        ngModelAttributes[item] = {attribute: item, bound: 'ng-' + item};
-      });
-
-      angular.forEach(expressionOnly, item => {
-        var propName = 'on' + item.substr(0, 1).toUpperCase() + item.substr(1);
-        ngModelAttributes[propName] = {expression: 'ng-' + item};
-      });
-
-      angular.forEach(attributeOnly, item => {
-        ngModelAttributes[item] = {attribute: item};
-      });
-      return ngModelAttributes;
-    }
-
-    function getEpValue(ep, name) {
-      return ep['templateOptions.' + name] ||
-        ep[`templateOptions['${name}']`] ||
-        ep[`templateOptions["${name}"]`];
-    }
-
-    function addIfNotPresent(nodes, attr, val) {
-      angular.forEach(nodes, node => {
-        if (!node.getAttribute(attr)) {
-          node.setAttribute(attr, val);
+        if (angular.isDefined(attrName) && angular.isDefined(attrVal)) {
+          addIfNotPresent(modelNodes, attrName, attrVal);
         }
       });
     }
   }
-};
+
+  // Utility functions
+  function getBuiltInAttributes() {
+    let ngModelAttributes = {
+      focus: {
+        attribute: 'formly-focus'
+      }
+    };
+    const boundOnly = [];
+    const bothBooleanAndBound = ['required', 'disabled'];
+    const bothAttributeAndBound = ['pattern', 'minlength'];
+    const expressionOnly = ['change', 'keydown', 'keyup', 'keypress', 'click', 'focus', 'blur'];
+    const attributeOnly = ['placeholder', 'min', 'max', 'tabindex', 'type'];
+    if (formlyConfig.extras.ngModelAttrsManipulatorPreferUnbound) {
+      bothAttributeAndBound.push('maxlength');
+    } else {
+      boundOnly.push('maxlength');
+    }
+
+    angular.forEach(boundOnly, item => {
+      ngModelAttributes[item] = {bound: 'ng-' + item};
+    });
+
+    angular.forEach(bothBooleanAndBound, item => {
+      ngModelAttributes[item] = {boolean: item, bound: 'ng-' + item};
+    });
+
+    angular.forEach(bothAttributeAndBound, item => {
+      ngModelAttributes[item] = {attribute: item, bound: 'ng-' + item};
+    });
+
+    angular.forEach(expressionOnly, item => {
+      var propName = 'on' + item.substr(0, 1).toUpperCase() + item.substr(1);
+      ngModelAttributes[propName] = {expression: 'ng-' + item};
+    });
+
+    angular.forEach(attributeOnly, item => {
+      ngModelAttributes[item] = {attribute: item};
+    });
+    return ngModelAttributes;
+  }
+
+  function getEpValue(ep, name) {
+    return ep['templateOptions.' + name] ||
+      ep[`templateOptions['${name}']`] ||
+      ep[`templateOptions["${name}"]`];
+  }
+
+  function addIfNotPresent(nodes, attr, val) {
+    angular.forEach(nodes, node => {
+      if (!node.getAttribute(attr)) {
+        node.setAttribute(attr, val);
+      }
+    });
+  }
+}
+
+export default addFormlyNgModelAttrsManipulator;

--- a/src/run/formlyNgModelAttrsManipulator.test.js
+++ b/src/run/formlyNgModelAttrsManipulator.test.js
@@ -1,4 +1,6 @@
 /* jshint maxlen:false */
+import {expect} from 'chai';
+
 describe('formlyNgModelAttrsManipulator', () => {
   beforeEach(window.module('formly'));
 

--- a/src/run/formlyNgModelAttrsManipulator.test.js
+++ b/src/run/formlyNgModelAttrsManipulator.test.js
@@ -1,184 +1,182 @@
 /* jshint maxlen:false */
-module.exports = ngModule => {
-  describe('formlyNgModelAttrsManipulator', () => {
-    beforeEach(window.module(ngModule.name));
+describe('formlyNgModelAttrsManipulator', () => {
+  beforeEach(window.module('formly'));
 
-    let formlyConfig, manipulator, scope, field, result, resultEl, resultNode;
-    const template = '<input ng-model="model[options.key]" />';
+  let formlyConfig, manipulator, scope, field, result, resultEl, resultNode;
+  const template = '<input ng-model="model[options.key]" />';
 
-    beforeEach(inject((_formlyConfig_, $rootScope) => {
-      formlyConfig = _formlyConfig_;
-      manipulator = formlyConfig.templateManipulators.preWrapper[0];
-      scope = $rootScope.$new();
-      scope.id = 'id';
-      field = {
-        data: {},
-        validation: {},
-        templateOptions: {}
-      };
-    }));
+  beforeEach(inject((_formlyConfig_, $rootScope) => {
+    formlyConfig = _formlyConfig_;
+    manipulator = formlyConfig.templateManipulators.preWrapper[0];
+    scope = $rootScope.$new();
+    scope.id = 'id';
+    field = {
+      data: {},
+      validation: {},
+      templateOptions: {}
+    };
+  }));
 
-    it(`should allow you to skip the manipulator`, () => {
-      field.data.skipNgModelAttrsManipulator = true;
+  it(`should allow you to skip the manipulator`, () => {
+    field.data.skipNgModelAttrsManipulator = true;
+    manipulate();
+    expect(result).to.equal(template);
+  });
+
+  it(`should have a limited number of automatically added attributes without any specific options`, () => {
+    manipulate();
+    // because different browsers place attributes in different places...
+    const spaces = '<input ng-model="model[options.key]" id="id" name="id">'.split(' ').length;
+    expect(result.split(' ').length).to.equal(spaces);
+    attrExists('ng-model');
+    attrExists('id');
+    attrExists('name');
+  });
+
+  it(`should automatically add an id and name`, () => {
+    manipulate();
+    expect(resultEl.attr('name')).to.eq('id');
+    expect(resultEl.attr('id')).to.eq('id');
+  });
+
+  describe(`ng-model-options`, () => {
+    it(`should be added if modelOptions is specified`, () => {
+      field.modelOptions = {};
       manipulate();
-      expect(result).to.equal(template);
+      attrExists('ng-model-options');
     });
 
-    it(`should have a limited number of automatically added attributes without any specific options`, () => {
+    it(`should change the value of ng-model if getterSetter is specified`, () => {
+      field.modelOptions = {getterSetter: true};
       manipulate();
-      // because different browsers place attributes in different places...
-      const spaces = '<input ng-model="model[options.key]" id="id" name="id">'.split(' ').length;
-      expect(result.split(' ').length).to.equal(spaces);
-      attrExists('ng-model');
-      attrExists('id');
-      attrExists('name');
+      expect(resultEl.attr('ng-model')).to.equal('options.value');
+    });
+  });
+
+
+  describe(`formly-custom-validation`, () => {
+    it(`shouldn't be added if there aren't validators or messages`, () => {
+      formlyCustomValidationPresence(false);
     });
 
-    it(`should automatically add an id and name`, () => {
+    it(`should be added if there are validators`, () => {
+      field.validators = {foo: 'bar'};
+      formlyCustomValidationPresence(true);
+    });
+
+    it(`should be added if there are messages`, () => {
+      field.validators = {foo: 'bar'};
+      field.validation.messages = {foo: '"bar"'};
+      formlyCustomValidationPresence(true);
+    });
+
+    it(`should be added if there are validators and messages`, () => {
+      field.validators = {foo: 'bar'};
+      field.validation.messages = {foo: '"bar"'};
+      formlyCustomValidationPresence(true);
+    });
+
+    function formlyCustomValidationPresence(present) {
       manipulate();
-      expect(resultEl.attr('name')).to.eq('id');
-      expect(resultEl.attr('id')).to.eq('id');
-    });
-
-    describe(`ng-model-options`, () => {
-      it(`should be added if modelOptions is specified`, () => {
-        field.modelOptions = {};
-        manipulate();
-        attrExists('ng-model-options');
-      });
-
-      it(`should change the value of ng-model if getterSetter is specified`, () => {
-        field.modelOptions = {getterSetter: true};
-        manipulate();
-        expect(resultEl.attr('ng-model')).to.equal('options.value');
-      });
-    });
-
-
-    describe(`formly-custom-validation`, () => {
-      it(`shouldn't be added if there aren't validators or messages`, () => {
-        formlyCustomValidationPresence(false);
-      });
-
-      it(`should be added if there are validators`, () => {
-        field.validators = {foo: 'bar'};
-        formlyCustomValidationPresence(true);
-      });
-
-      it(`should be added if there are messages`, () => {
-        field.validators = {foo: 'bar'};
-        field.validation.messages = {foo: '"bar"'};
-        formlyCustomValidationPresence(true);
-      });
-
-      it(`should be added if there are validators and messages`, () => {
-        field.validators = {foo: 'bar'};
-        field.validation.messages = {foo: '"bar"'};
-        formlyCustomValidationPresence(true);
-      });
-
-      function formlyCustomValidationPresence(present) {
-        manipulate();
-        attrExists('formly-custom-validation', !present);
-      }
-    });
-
-    describe(`templateOptions attributes`, () => {
-      describe(`boolean attributes`, () => {
-
-        testAttribute('required');
-        testAttribute('disabled');
-
-        function testAttribute(name) {
-          it(`should allow you to specify 'true' for ${name}`, () => {
-            field.templateOptions = {
-              [name]: true
-            };
-            manipulate();
-            attrExists(name);
-          });
-
-          it(`should allow you to specify 'false' for ${name}`, () => {
-            field.templateOptions = {
-              [name]: false
-            };
-            manipulate();
-            attrExists(name, false);
-            attrExists(`ng-${name}`, false);
-          });
-        }
-      });
-
-      describe(`attributeOnly`, () => {
-
-        ['placeholder', 'min', 'max', 'tabindex', 'type'].forEach(testAttribute);
-
-        function testAttribute(name) {
-          it(`should be placed as an attribute if it is present in the templateOptions`, () => {
-            field.templateOptions = {
-              [name]: 'Ammon'
-            };
-            manipulate();
-            expect(resultEl.attr(name)).to.eq('Ammon');
-          });
-
-          it(`should be placed as an attribute with {{expression}} if it is present in the expressionProperties`, () => {
-            field.expressionProperties = {
-              ['templateOptions.' + name]: 'Ammon'
-            };
-            manipulate();
-            expect(resultEl.attr(name)).to.eq(`{{options.templateOptions['${name}']}}`);
-          });
-        }
-      });
-
-      describe(`preferUnbound`, () => {
-        it(`should prefer to specify maxlength as ng-maxlegnth even when it's not in expressionProperties`, () => {
-          field.templateOptions = {
-            maxlength: 3
-          };
-          manipulate();
-          expect(resultEl.attr('ng-maxlength')).to.eq(`options.templateOptions['maxlength']`);
-          attrExists('maxlength', false);
-        });
-
-        it(`should allow you to specify maxlength that gets set to maxlength if it's not in expressionProperties`, () => {
-          formlyConfig.extras.ngModelAttrsManipulatorPreferUnbound = true;
-          field.templateOptions = {
-            maxlength: 3
-          };
-          manipulate();
-          attrExists('ng-maxlength', false);
-          expect(resultEl.attr('maxlength')).to.eq('3');
-          formlyConfig.extras.ngModelAttrsManipulatorPreferUnbound = false;
-        });
-
-        it(`should still allow maxlength work with expressionProperties`, () => {
-          field.expressionProperties = {
-            'templateOptions.maxlength': '3'
-          };
-          manipulate();
-          expect(resultEl.attr('ng-maxlength')).to.eq(`options.templateOptions['maxlength']`);
-          attrExists('maxlength', false);
-        });
-
-      });
-    });
-
-
-    function manipulate() {
-      result = manipulator(template, field, scope);
-      resultEl = angular.element(result);
-      resultNode = resultEl[0];
-    }
-
-    function attrExists(name, notExists) {
-      const attr = resultNode.getAttribute(name);
-      if (notExists) {
-        expect(attr).to.be.null;
-      } else {
-        expect(attr).to.be.defined;
-      }
+      attrExists('formly-custom-validation', !present);
     }
   });
-};
+
+  describe(`templateOptions attributes`, () => {
+    describe(`boolean attributes`, () => {
+
+      testAttribute('required');
+      testAttribute('disabled');
+
+      function testAttribute(name) {
+        it(`should allow you to specify 'true' for ${name}`, () => {
+          field.templateOptions = {
+            [name]: true
+          };
+          manipulate();
+          attrExists(name);
+        });
+
+        it(`should allow you to specify 'false' for ${name}`, () => {
+          field.templateOptions = {
+            [name]: false
+          };
+          manipulate();
+          attrExists(name, false);
+          attrExists(`ng-${name}`, false);
+        });
+      }
+    });
+
+    describe(`attributeOnly`, () => {
+
+      ['placeholder', 'min', 'max', 'tabindex', 'type'].forEach(testAttribute);
+
+      function testAttribute(name) {
+        it(`should be placed as an attribute if it is present in the templateOptions`, () => {
+          field.templateOptions = {
+            [name]: 'Ammon'
+          };
+          manipulate();
+          expect(resultEl.attr(name)).to.eq('Ammon');
+        });
+
+        it(`should be placed as an attribute with {{expression}} if it is present in the expressionProperties`, () => {
+          field.expressionProperties = {
+            ['templateOptions.' + name]: 'Ammon'
+          };
+          manipulate();
+          expect(resultEl.attr(name)).to.eq(`{{options.templateOptions['${name}']}}`);
+        });
+      }
+    });
+
+    describe(`preferUnbound`, () => {
+      it(`should prefer to specify maxlength as ng-maxlegnth even when it's not in expressionProperties`, () => {
+        field.templateOptions = {
+          maxlength: 3
+        };
+        manipulate();
+        expect(resultEl.attr('ng-maxlength')).to.eq(`options.templateOptions['maxlength']`);
+        attrExists('maxlength', false);
+      });
+
+      it(`should allow you to specify maxlength that gets set to maxlength if it's not in expressionProperties`, () => {
+        formlyConfig.extras.ngModelAttrsManipulatorPreferUnbound = true;
+        field.templateOptions = {
+          maxlength: 3
+        };
+        manipulate();
+        attrExists('ng-maxlength', false);
+        expect(resultEl.attr('maxlength')).to.eq('3');
+        formlyConfig.extras.ngModelAttrsManipulatorPreferUnbound = false;
+      });
+
+      it(`should still allow maxlength work with expressionProperties`, () => {
+        field.expressionProperties = {
+          'templateOptions.maxlength': '3'
+        };
+        manipulate();
+        expect(resultEl.attr('ng-maxlength')).to.eq(`options.templateOptions['maxlength']`);
+        attrExists('maxlength', false);
+      });
+
+    });
+  });
+
+
+  function manipulate() {
+    result = manipulator(template, field, scope);
+    resultEl = angular.element(result);
+    resultNode = resultEl[0];
+  }
+
+  function attrExists(name, notExists) {
+    const attr = resultNode.getAttribute(name);
+    if (notExists) {
+      expect(attr).to.be.null;
+    } else {
+      expect(attr).to.be.defined;
+    }
+  }
+});

--- a/src/run/index.js
+++ b/src/run/index.js
@@ -1,4 +1,0 @@
-module.exports = ngModule => {
-  require('./formlyNgModelAttrsManipulator')(ngModule);
-  require('./formlyCustomTags')(ngModule);
-};

--- a/src/services/formlyUtil.js
+++ b/src/services/formlyUtil.js
@@ -1,11 +1,5 @@
-const utils = require('../other/utils');
+import utils from '../other/utils';
 
-module.exports = ngModule => {
-  ngModule.factory('formlyUtil', formlyUtil);
-
-  formlyUtil.tests = ON_TEST ? require('./formlyUtil.test')(ngModule) : null;
-
-  function formlyUtil() {
-    return utils;
-  }
-};
+export default function formlyUtil() {
+  return utils;
+}

--- a/src/services/formlyUtil.test.js
+++ b/src/services/formlyUtil.test.js
@@ -1,3 +1,5 @@
+import {expect} from 'chai';
+
 describe('formlyUtil', () => {
   beforeEach(window.module('formly'));
 

--- a/src/services/formlyUtil.test.js
+++ b/src/services/formlyUtil.test.js
@@ -1,124 +1,122 @@
-module.exports = ngModule => {
-  describe('formlyUtil', () => {
-    beforeEach(window.module(ngModule.name));
+describe('formlyUtil', () => {
+  beforeEach(window.module('formly'));
 
-    describe('reverseDeepMerge', () => {
-      let merge;
-      beforeEach(inject(function(formlyUtil) {
-        merge = formlyUtil.reverseDeepMerge;
-      }));
+  describe('reverseDeepMerge', () => {
+    let merge;
+    beforeEach(inject(function(formlyUtil) {
+      merge = formlyUtil.reverseDeepMerge;
+    }));
 
-      it(`should modify and prefer the first object`, () => {
-        let firstObj = {
-          obj1a: {
-            obj2a: {
-              string3a: 'Hello world',
-              number3a: 4,
-              bool3a: false
-            }
-          },
-          arry1a: [
-            1, 2, 3, 4
-          ]
-        };
-        let secondObj = {
-          obj1a: {
-            obj2a: {
-              string3a: 'Should not win',
-              string3b: 'Should exist',
-              number3a: 5,
-              bool3a: true,
-              bool3b: false
-            }
+    it(`should modify and prefer the first object`, () => {
+      let firstObj = {
+        obj1a: {
+          obj2a: {
+            string3a: 'Hello world',
+            number3a: 4,
+            bool3a: false
           }
-        };
+        },
+        arry1a: [
+          1, 2, 3, 4
+        ]
+      };
+      let secondObj = {
+        obj1a: {
+          obj2a: {
+            string3a: 'Should not win',
+            string3b: 'Should exist',
+            number3a: 5,
+            bool3a: true,
+            bool3b: false
+          }
+        }
+      };
 
-        let thirdObj = {
-          obj1a: 'false',
-          arry1a: [
-            4, 3, 2, 1, 0
-          ]
-        };
+      let thirdObj = {
+        obj1a: 'false',
+        arry1a: [
+          4, 3, 2, 1, 0
+        ]
+      };
 
-        let result = {
-          obj1a: {
-            obj2a: {
-              string3a: 'Hello world',
-              string3b: 'Should exist',
-              number3a: 4,
-              bool3a: false,
-              bool3b: false
-            }
-          },
-          arry1a: [
-            1, 2, 3, 4, 0
-          ]
-        };
+      let result = {
+        obj1a: {
+          obj2a: {
+            string3a: 'Hello world',
+            string3b: 'Should exist',
+            number3a: 4,
+            bool3a: false,
+            bool3b: false
+          }
+        },
+        arry1a: [
+          1, 2, 3, 4, 0
+        ]
+      };
 
-        merge(firstObj, secondObj, thirdObj);
-        expect(firstObj).to.eql(result);
-      });
-
-      it(`should allow for adding of empty objects`, () => {
-        let firstObj = {
-          a: 'a',
-          b: 'b'
-        };
-
-        let secondObj = {
-          data: {},
-          templateOptions: {},
-          validation: {}
-        };
-
-        let result = {
-          a: 'a',
-          b: 'b',
-          data: {},
-          templateOptions: {},
-          validation: {}
-        };
-
-        merge(firstObj, secondObj);
-        expect(firstObj).to.eql(result);
-      });
+      merge(firstObj, secondObj, thirdObj);
+      expect(firstObj).to.eql(result);
     });
 
-    describe('findByNodeName', () => {
-      let find, $compile, scope;
-      beforeEach(inject(function(_$compile_, $rootScope, formlyUtil) {
-        $compile = _$compile_;
-        scope = $rootScope;
-        find = formlyUtil.findByNodeName;
-      }));
+    it(`should allow for adding of empty objects`, () => {
+      let firstObj = {
+        a: 'a',
+        b: 'b'
+      };
 
-      it('should find an element by nodeName from a single root', () => {
-        const template =
-          '<div><form><input></form></div>';
-        const el = $compile(template)(scope);
-        const found = find(el, 'input');
-        expect(found.length).to.equal(1);
-        expect(found.prop('nodeName')).to.equal('INPUT');
-      });
+      let secondObj = {
+        data: {},
+        templateOptions: {},
+        validation: {}
+      };
 
-      it('should find an element by nodeName from multiple root', () => {
-        const template =
-          '<div><form><input></form></div>' +
-          '<span><a><i></i></a>';
-        const el = $compile(template)(scope);
-        const found = find(el, 'i');
-        expect(found.length).to.equal(1);
-        expect(found.prop('nodeName')).to.equal('I');
-      });
+      let result = {
+        a: 'a',
+        b: 'b',
+        data: {},
+        templateOptions: {},
+        validation: {}
+      };
 
-      it('should return undefined when a node can\'t be found', () => {
-        const template =
-          '<div><form><input></form></div>';
-        const el = $compile(template)(scope);
-        const found = find(el, 'bla');
-        expect(found).to.be.undefined;
-      });
-
+      merge(firstObj, secondObj);
+      expect(firstObj).to.eql(result);
     });
   });
-};
+
+  describe('findByNodeName', () => {
+    let find, $compile, scope;
+    beforeEach(inject(function(_$compile_, $rootScope, formlyUtil) {
+      $compile = _$compile_;
+      scope = $rootScope;
+      find = formlyUtil.findByNodeName;
+    }));
+
+    it('should find an element by nodeName from a single root', () => {
+      const template =
+        '<div><form><input></form></div>';
+      const el = $compile(template)(scope);
+      const found = find(el, 'input');
+      expect(found.length).to.equal(1);
+      expect(found.prop('nodeName')).to.equal('INPUT');
+    });
+
+    it('should find an element by nodeName from multiple root', () => {
+      const template =
+        '<div><form><input></form></div>' +
+        '<span><a><i></i></a>';
+      const el = $compile(template)(scope);
+      const found = find(el, 'i');
+      expect(found.length).to.equal(1);
+      expect(found.prop('nodeName')).to.equal('I');
+    });
+
+    it('should return undefined when a node can\'t be found', () => {
+      const template =
+        '<div><form><input></form></div>';
+      const el = $compile(template)(scope);
+      const found = find(el, 'bla');
+      expect(found).to.be.undefined;
+    });
+
+  });
+});

--- a/src/services/formlyWarn.js
+++ b/src/services/formlyWarn.js
@@ -1,13 +1,13 @@
-module.exports = ngModule => {
-  ngModule.factory('formlyWarn', function (formlyConfig, formlyErrorAndWarningsUrlPrefix, $log) {
-    return function warn() {
-      if (!formlyConfig.disableWarnings) {
-        var args = Array.prototype.slice.call(arguments);
-        var warnInfoSlug = args.shift();
-        args.unshift('Formly Warning:');
-        args.push(`${formlyErrorAndWarningsUrlPrefix}${warnInfoSlug}`);
-        $log.warn(...args);
-      }
-    };
-  });
-};
+function formlyWarn (formlyConfig, formlyErrorAndWarningsUrlPrefix, $log) {
+  return function warn() {
+    if (!formlyConfig.disableWarnings) {
+      var args = Array.prototype.slice.call(arguments);
+      var warnInfoSlug = args.shift();
+      args.unshift('Formly Warning:');
+      args.push(`${formlyErrorAndWarningsUrlPrefix}${warnInfoSlug}`);
+      $log.warn(...args);
+    }
+  };
+}
+
+export default formlyWarn;

--- a/src/services/formlyWarn.js
+++ b/src/services/formlyWarn.js
@@ -1,4 +1,4 @@
-function formlyWarn (formlyConfig, formlyErrorAndWarningsUrlPrefix, $log) {
+export default function formlyWarn (formlyConfig, formlyErrorAndWarningsUrlPrefix, $log) {
   return function warn() {
     if (!formlyConfig.disableWarnings) {
       var args = Array.prototype.slice.call(arguments);
@@ -9,5 +9,3 @@ function formlyWarn (formlyConfig, formlyErrorAndWarningsUrlPrefix, $log) {
     }
   };
 }
-
-export default formlyWarn;

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,4 +1,0 @@
-module.exports = ngModule => {
-  require('./formlyUtil')(ngModule);
-  require('./formlyWarn')(ngModule);
-};


### PR DESCRIPTION
@kentcdodds Thought you may be interested in this.  This PR overhauls the modularity in angular-formly to leverage ES6 modules as much as possible, then integrating into angular modules just where necessary.  This has several benefits:
1. The formly API becomes much more agnostic of the angular API, which is good for multiple reasons including Angular v2 portability and (potentially) re-use outside of Angular if the need/desire arises.
2. Module deps become much easier to reason about by extracting the angular module API bits outside of the formly modules (they shouldn't need to know how to register themselves with angular using module.factory, etc.
3. Remove the awkward conditional requires related to testing inside of the current modules.  Note that getting rid of these probably also fixes #186.
4. Leverage ES6 modules FTW!

There are still some items that can be improved upon (such as more explicit dep usage within modules using angular utility functions), but I think this is a solid foundation.

Let me know what you think!

P.S.  I found that GitHub's default diff view makes these changes look way more intense than they actually are.  In that case, using the ?w=1 query parameter on the URL of a diff page removes the whitespace diffing and makes the changes much more clearer:

https://github.com/formly-js/angular-formly/compare/master...sparty02:es6-modules?w=1
