### PR TITLE
Added unit tests and example for ng-required

### DIFF
--- a/demo/app/states/root/components/data/examples.js
+++ b/demo/app/states/root/components/data/examples.js
@@ -147,6 +147,11 @@ export default [
         title: 'Integrate with angular-wizard',
         slug: 'angular-wizard',
         jsbinId: 'sajeso'
+      },
+      {
+        title: 'Toggle required field validation',
+        slug: 'toggle-required',
+        jsbinId: 'fuwaji'
       }
     ]
   },

--- a/src/run/formlyNgModelAttrsManipulator.test.js
+++ b/src/run/formlyNgModelAttrsManipulator.test.js
@@ -106,6 +106,16 @@ module.exports = ngModule => {
             attrExists(name, false);
             attrExists(`ng-${name}`, false);
           });
+
+          it(`should allow you to specify expressionProperties for ${name}`, () => {
+            field.expressionProperties= {
+              [`templateOptions.${name}`]: 'someExpression'
+            };
+            manipulate();
+            attrExists(name, false);
+            attrExists(`ng-${name}`);
+            expect(resultEl.attr(`ng-${name}`)).to.eq(`options.templateOptions['${name}']`);
+          });
         }
       });
 


### PR DESCRIPTION
I recently was struggling to understand how to use ngModelAttrsManipluator to set a dynamic ng-required.
So I added a unit test and a new jsbin example (as requested in #156 ;-))

A fresh new PR with only a single commit! [Stack Overflow](http://stackoverflow.com/questions/5256021/send-a-pull-request-on-github-for-only-latest-commit) FTW!