### PR TITLE
Support test coverage via karma

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -42,6 +42,10 @@ function getConfig(context) {
       // available reporters: https://npmjs.org/browse/keyword/karma-reporter
       reporters: ['progress', 'coverage'],
 
+      coverageReporter: {
+        type: 'lcov', // lcov or lcovonly are required for generating lcov.info files
+        dir: 'coverage/'
+      },
 
       // web server port
       port: 9876,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,7 +18,7 @@ function getConfig(context) {
   delete testConfig.externals; // need angular in test context
   var entry = path.join(testConfig.context, testConfig.entry);
   var preprocessors = {};
-  preprocessors[entry] = ['webpack'];
+  preprocessors[entry] = ['webpack', 'coverage'];
 
   return function(config) {
     config.set({
@@ -40,7 +40,7 @@ function getConfig(context) {
       // test results reporter to use
       // possible values: 'dots', 'progress'
       // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-      reporters: ['progress'],
+      reporters: ['progress', 'coverage'],
 
 
       // web server port
@@ -74,6 +74,7 @@ function getConfig(context) {
       plugins: [
         require('karma-webpack'),
         'karma-mocha',
+        'karma-coverage',
         'karma-chai',
         'karma-chrome-launcher',
         'karma-firefox-launcher'

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "karma": "^0.12.31",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^0.1.7",
+    "karma-coverage": "^0.3.1",
     "karma-firefox-launcher": "^0.1.4",
     "karma-mocha": "^0.1.10",
     "karma-webpack": "^1.5.0",


### PR DESCRIPTION
This commit provides test coverage stats via a karma plugin (using Instanbul under the covers).  Closes #79.