### PR TITLE
Coveralls.io Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Status:
 [![npm version](https://img.shields.io/npm/v/angular-formly.svg?style=flat-square)](https://www.npmjs.org/package/angular-formly)
 [![npm downloads](https://img.shields.io/npm/dm/angular-formly.svg?style=flat-square)](https://www.npmjs.org/package/angular-formly)
 [![Build Status](https://img.shields.io/travis/formly-js/angular-formly.svg?style=flat-square)](https://travis-ci.org/formly-js/angular-formly)
+[![Coverage Status](https://coveralls.io/repos/formly-js/angular-formly/badge.svg)](https://coveralls.io/r/formly-js/angular-formly)
 
 Links:
 [![Documentation](https://img.shields.io/badge/API-Docs-red.svg?style=flat-square)](http://docs.angular-formly.com)

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -40,7 +40,7 @@ function getConfig(context) {
       // test results reporter to use
       // possible values: 'dots', 'progress'
       // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-      reporters: ['progress', 'coverage'],
+      reporters: ['progress', 'coverage', 'coveralls'],
 
       coverageReporter: {
         type: 'lcov', // lcov or lcovonly are required for generating lcov.info files
@@ -79,6 +79,7 @@ function getConfig(context) {
         require('karma-webpack'),
         'karma-mocha',
         'karma-coverage',
+        'karma-coveralls',
         'karma-chai',
         'karma-chrome-launcher',
         'karma-firefox-launcher'

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -42,6 +42,10 @@ function getConfig(context) {
       // available reporters: https://npmjs.org/browse/keyword/karma-reporter
       reporters: ['progress', 'coverage'],
 
+      coverageReporter: {
+        type: 'lcov', // lcov or lcovonly are required for generating lcov.info files
+        dir: 'coverage/'
+      },
 
       // web server port
       port: 9876,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,7 +18,7 @@ function getConfig(context) {
   delete testConfig.externals; // need angular in test context
   var entry = path.join(testConfig.context, testConfig.entry);
   var preprocessors = {};
-  preprocessors[entry] = ['webpack'];
+  preprocessors[entry] = ['webpack', 'coverage'];
 
   return function(config) {
     config.set({
@@ -40,7 +40,7 @@ function getConfig(context) {
       // test results reporter to use
       // possible values: 'dots', 'progress'
       // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-      reporters: ['progress'],
+      reporters: ['progress', 'coverage'],
 
 
       // web server port
@@ -74,6 +74,7 @@ function getConfig(context) {
       plugins: [
         require('karma-webpack'),
         'karma-mocha',
+        'karma-coverage',
         'karma-chai',
         'karma-chrome-launcher',
         'karma-firefox-launcher'

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "karma": "^0.12.31",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^0.1.7",
+    "karma-coverage": "^0.3.1",
     "karma-firefox-launcher": "^0.1.4",
     "karma-mocha": "^0.1.10",
     "karma-webpack": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^0.1.7",
     "karma-coverage": "^0.3.1",
+    "karma-coveralls": "^0.1.5",
     "karma-firefox-launcher": "^0.1.4",
     "karma-mocha": "^0.1.10",
     "karma-webpack": "^1.5.0",


### PR DESCRIPTION
This provides the necessary configuration via karma to publish coverage results to coveralls.io (pending some environment config by @kentcdodds for coveralls.io authentication).  In addition, a new test coverage badge is being added to the README.  Fixes #78 