### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "devDependencies": {
     "angular": "^1.3.11",
     "angular-mocks": "^1.3.11",
-    "api-check": "^7.0.0-beta.2",
     "babel-core": "^4.4.6",
     "babel-loader": "^4.0.0",
     "chai": "^1.10.0",


### PR DESCRIPTION
api-check isn't intended to be in here as a dev-dependency is it?  If so, it probably shouldn't be referring to the beta version.  (It's causing an issue on an unmet peer dependency when npm installing formly from source).