### PR TITLE
Allows template and templateUrl to be functions.

### DIFF
--- a/src/directives/formly-field.js
+++ b/src/directives/formly-field.js
@@ -262,11 +262,16 @@ function formlyField($http, $q, $compile, $templateCache, formlyConfig, formlyVa
         `Type '${options.type}' has not template. On element:`, options
       );
     }
-    return getTemplate(template || templateUrl, !template);
+
+    return getTemplate(template || templateUrl, !template, options);
   }
 
 
-  function getTemplate(template, isUrl) {
+  function getTemplate(template, isUrl, options) {
+    if(angular.isFunction(template)){
+      template = template(options);
+    }
+
     if (!isUrl) {
       return $q.when(template);
     } else {

--- a/src/directives/formly-field.test.js
+++ b/src/directives/formly-field.test.js
@@ -339,6 +339,68 @@ describe('formly-field', function() {
     });
   });
 
+  describe(`template and templateUrl properties`, () => {
+    let $templateCache;
+    var expectedTemplateText = 'sweet mercy';
+    
+    beforeEach(inject((_$templateCache_) => {
+      $templateCache = _$templateCache_;
+      $templateCache.put('templateUrlTest.html', expectedTemplateText);
+    }));
+
+    it('should allow template property to be a function', () => {
+      scope.fields = [
+        { 
+          template: function(options){
+            return expectedTemplateText;
+          }
+        }
+      ];
+
+      const el = compileAndDigest();
+
+      var fieldEl = angular.element(el[0].querySelector('.formly-field'));
+      expect(fieldEl.text()).to.equal(expectedTemplateText);
+    });
+
+    it('should allow template property to be a string', () => {
+      scope.fields = [
+        { template: expectedTemplateText }
+      ];
+
+      const el = compileAndDigest();
+
+      var fieldEl = angular.element(el[0].querySelector('.formly-field'));
+      expect(fieldEl.text()).to.equal(expectedTemplateText);
+    });
+
+    it('should allow templateUrl property to be a function', () => {
+       scope.fields = [
+        { 
+          templateUrl: function(options){
+            return 'templateUrlTest.html';
+          }
+        }
+      ];
+
+      const el = compileAndDigest();
+
+      var fieldEl = angular.element(el[0].querySelector('.formly-field'));
+      expect(fieldEl.text()).to.equal(expectedTemplateText);
+    });
+
+    it('should allow templateUrl property to be a string', () => {
+      scope.fields = [
+        { templateUrl: 'templateUrlTest.html' }
+      ];
+
+      const el = compileAndDigest();
+
+      var fieldEl = angular.element(el[0].querySelector('.formly-field'));
+      expect(fieldEl.text()).to.equal(expectedTemplateText);
+    });
+  });
+
   describe(`type apiCheck`, () => {
     let type = 'input';
     beforeEach(() => {

--- a/src/providers/formlyApiCheck.js
+++ b/src/providers/formlyApiCheck.js
@@ -58,8 +58,14 @@ const formlyWrapperType = apiCheck.shape({
 let fieldOptionsApiShape = {
   $$hashKey: apiCheck.any.optional,
   type: apiCheck.shape.ifNot(['template', 'templateUrl'], apiCheck.string).optional,
-  template: apiCheck.shape.ifNot(['type', 'templateUrl'], apiCheck.string).optional,
-  templateUrl: apiCheck.shape.ifNot(['type', 'template'], apiCheck.string).optional,
+  template: apiCheck.shape.ifNot(
+    ['type', 'templateUrl'], 
+    apiCheck.oneOfType([apiCheck.string, apiCheck.func])
+  ).optional,
+  templateUrl: apiCheck.shape.ifNot(
+    ['type', 'template'],
+    apiCheck.oneOfType([apiCheck.string, apiCheck.func])
+  ).optional,
   key: apiCheck.oneOfType([apiCheck.string, apiCheck.number]),
   model: apiCheck.object.optional,
   expressionProperties: apiCheck.objectOf(apiCheck.oneOfType([
@@ -128,8 +134,8 @@ typeOptionsDefaultOptions.key = apiCheck.string.optional;
 
 let formlyTypeOptions = apiCheck.shape({
   name: apiCheck.string,
-  template: apiCheck.shape.ifNot('templateUrl', apiCheck.string).optional,
-  templateUrl: apiCheck.shape.ifNot('template', apiCheck.string).optional,
+  template: apiCheck.shape.ifNot('templateUrl', apiCheck.oneOfType([apiCheck.string, apiCheck.func])).optional,
+  templateUrl: apiCheck.shape.ifNot('template', apiCheck.oneOfType([apiCheck.string, apiCheck.func])).optional,
   controller: apiCheck.oneOfType([
     apiCheck.func, apiCheck.string, apiCheck.array
   ]).optional,


### PR DESCRIPTION
Allows template and templateUrl properties of both a field type or field definition be functions.

Use case: A select type that uses a custom select directive such as ui-select which can be a single or multiple select which require different templates.