### PR TITLE
`templateUrl` is no longer ignored when extending a type which defines `template`

### DIFF
--- a/src/providers/formlyConfig.js
+++ b/src/providers/formlyConfig.js
@@ -67,6 +67,15 @@ function formlyConfig(formlyUsabilityProvider, formlyApiCheck) {
     extendTypeValidateOptionsFunction(options, extendsType);
     extendTypeDefaultOptions(options, extendsType);
     utils.reverseDeepMerge(options, extendsType);
+    extendTemplate(options, extendsType);
+  }
+
+  function extendTemplate(options, extendsType){
+    if(options.template && extendsType.templateUrl){
+      delete options.templateUrl;
+    } else if(options.templateUrl && extendsType.template){
+      delete options.template;
+    }
   }
 
   function extendTypeControllerFunction(options, extendsType) {

--- a/src/providers/formlyConfig.test.js
+++ b/src/providers/formlyConfig.test.js
@@ -267,6 +267,42 @@ describe('formlyConfig', () => {
           });
 
         });
+        
+        describe(`template/templateUrl Cases`, () => {
+          it('should use templateUrl if type defines it and its parent has template defined', function(){
+            setterFn([
+              {
+                name,
+                template
+              },
+              {
+                name: 'type2',
+                extends: name,
+                templateUrl
+              }
+            ]);
+
+            expect(getterFn('type2').templateUrl).not.to.be.undefined;
+            expect(getterFn('type2').template).to.be.undefined;
+          });
+
+          it('should use template if type defines it and its parent had templateUrl defined', function(){
+            setterFn([
+              {
+                name,
+                templateUrl
+              },
+              {
+                name: 'type2',
+                extends: name,
+                template
+              }
+            ]);
+
+            expect(getterFn('type2').template).not.to.be.undefined;
+            expect(getterFn('type2').templateUrl).to.be.undefined;
+          });
+        });
 
         describe(`function cases`, () => {
           let args, parentFn, childFn, parentDefaultOptions, childDefaultOptions,


### PR DESCRIPTION
`templateUrl` is no longer ignored when extending a type which defines `template`

This also fixes the inverse.

Fixes #288