### PR TITLE
Added support for allowing 'template' property to be an empty string.

### DIFF
--- a/src/directives/formly-field.js
+++ b/src/directives/formly-field.js
@@ -331,17 +331,25 @@ function formlyField($http, $q, $compile, $templateCache, formlyConfig, formlyVa
   }
 
   function getFieldTemplate(options) {
+    function fromOptionsOrType(key, type){
+      if(angular.isDefined(options[key])){
+        return options[key];
+      } else if(type && angular.isDefined(type[key])){
+        return type[key];
+      }
+    }
+
     let type = formlyConfig.getType(options.type, true, options);
-    let template = options.template || type && type.template;
-    let templateUrl = options.templateUrl || type && type.templateUrl;
-    if (!template && !templateUrl) {
+    let template = fromOptionsOrType('template', type);
+    let templateUrl = fromOptionsOrType('templateUrl', type);
+    if (angular.isUndefined(template) && !templateUrl) {
       throw formlyUsability.getFieldError(
         'type-type-has-no-template',
         `Type '${options.type}' has not template. On element:`, options
       );
     }
 
-    return getTemplate(template || templateUrl, !template, options);
+    return getTemplate(templateUrl || template, angular.isUndefined(template), options);
   }
 
 

--- a/src/directives/formly-field.test.js
+++ b/src/directives/formly-field.test.js
@@ -394,6 +394,17 @@ describe('formly-field', function() {
       expect(fieldEl.text()).to.equal(expectedTemplateText);
     });
 
+    it('should allow template property to be an empty string', () => {
+      scope.fields = [
+        {template: ''},
+      ];
+
+      const el = compileAndDigest();
+
+      var fieldEl = angular.element(el[0].querySelector('.formly-field'));
+      expect(fieldEl.text()).to.equal('');
+    });
+
     it('should allow templateUrl property to be a function', () => {
       scope.fields = [
         {


### PR DESCRIPTION
Added support for allowing 'template' property to be an empty string.

Would have allowed templateUrl to also be an empty string too but doing causes errors when the templateUrl is attempted to be loaded.

Fixes #285