### PR TITLE
add support for data-ng-model in custom templates

### DIFF
--- a/src/directives/formly-field.js
+++ b/src/directives/formly-field.js
@@ -257,7 +257,7 @@ function formlyField($http, $q, $compile, $templateCache, formlyConfig, formlyVa
         return;
       }
       const templateEl = angular.element(`<div>${templateString}</div>`);
-      const ngModelNode = templateEl[0].querySelector('[ng-model]');
+      const ngModelNode = templateEl[0].querySelector('[ng-model],[data-ng-model]');
       if (ngModelNode && ngModelNode.getAttribute('name')) {
         watchFieldNameOrExistence(ngModelNode.getAttribute('name'));
       }

--- a/src/directives/formly-field.test.js
+++ b/src/directives/formly-field.test.js
@@ -763,6 +763,16 @@ describe('formly-field', function() {
     });
   });
 
+  describe(`with a div data-ng-model`,() => {
+    it(`should have a form-controller`, () => {
+      const template = `<div data-ng-model="model[options.key]"> </div>`;
+      scope.fields = [getNewField({template: template})];
+      compileAndDigestAndSetIsolateScope();
+      expect(isolateScope.fc).to.exist;
+      expect(field.formControl).to.exist;
+    });
+  });
+
   describe(`with custom errorExistsAndShouldBeVisible expression`, () => {
     beforeEach(() => {
       scope.fields = [getNewField({validators: {foo: 'false'}})];

--- a/src/run/formlyNgModelAttrsManipulator.js
+++ b/src/run/formlyNgModelAttrsManipulator.js
@@ -18,7 +18,7 @@ function addFormlyNgModelAttrsManipulator(formlyConfig) {
       return template;
     }
     el.innerHTML = template;
-    var modelNodes = el.querySelectorAll('[ng-model]');
+    var modelNodes = el.querySelectorAll('[ng-model], [data-ng-model]');
     if (!modelNodes || !modelNodes.length) {
       return template;
     }


### PR DESCRIPTION
Some templates may use a data-ng-model attribute instead of a ng-model attribute. This PR update the query selector in order to include those nodes. 