### PR TITLE
Fixed bug from uninitialized form group

### DIFF
--- a/src/directives/formly-form.js
+++ b/src/directives/formly-form.js
@@ -157,7 +157,7 @@ function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpol
 
     function updateInitialValue() {
       angular.forEach($scope.fields, field => {
-        if (isFieldGroup(field)) {
+        if (isFieldGroup(field) && field.options) {
           field.options.updateInitialValue();
         } else {
           field.updateInitialValue();
@@ -167,7 +167,7 @@ function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpol
 
     function resetModel() {
       angular.forEach($scope.fields, field => {
-        if (isFieldGroup(field)) {
+        if (isFieldGroup(field) && field.options) {
           field.options.resetModel();
         } else {
           field.resetModel();


### PR DESCRIPTION
When the form group is uninitialized but `resetModel` or `updateInitialValue` is called, an error is raised because the field is not initialized with the options property as yet. This can happen if the form group has a `hideExpression` which removes it from the DOM initially and `formly-field` directive hasn't extended it with the options property as yet.

To fix this we need a property that identifies that the field has been properly initialized. The `options` property fulfils this role, so I'm checking it accordingly for both these functions.