### PR TITLE
Added ability to add custom class to ngTransclude. Fixes #398.

### DIFF
--- a/src/directives/formly-form.js
+++ b/src/directives/formly-form.js
@@ -50,7 +50,7 @@ function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpol
                form-options="options"
                index="$index">
           </${fieldRootEl}>
-          <div ng-transclude></div>
+          <div ng-transclude class="${getTranscludeClass()}"></div>
         </${rootEl}>
       `;
 
@@ -85,6 +85,10 @@ function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpol
         formName = `${$interpolate.startSymbol()}::'formly_' + ${bindName}${$interpolate.endSymbol()}`;
       }
       return formName;
+    }
+
+    function getTranscludeClass() {
+      return attrs.transcludeClass || '';
     }
 
     function copyAttributes(attributes) {

--- a/src/directives/formly-form.test.js
+++ b/src/directives/formly-form.test.js
@@ -149,7 +149,7 @@ describe('formly-form', () => {
     expect(() => scope.$digest()).to.not.throw();
   });
 
-  describe.skip(`ngTransclude element`, () => {
+  describe(`ngTransclude element`, () => {
     it(`should have the specified className`, () => {
       const el = compileAndDigest(`
       <formly-form model="model" fields="fields" form="theForm" transclude-class="foo yeah"></formly-form>


### PR DESCRIPTION
Yes, there are three commits apparently in this PR. I realized that you said the wrong issue number in your instructions, so I went back to amend the commit to reference #398 correctly.

Hope I did this correctly! :)
