### PR TITLE
5th try is the charm, actually fixes #432 with some additional tests …

### DIFF
--- a/src/directives/formly-field.js
+++ b/src/directives/formly-field.js
@@ -360,6 +360,7 @@ function formlyField($http, $q, $compile, $templateCache, $interpolate, formlyCo
       function addFormatters() {
         setParsersOrFormatters('formatters');
         const ctrl = scope.fc;
+        const formWasPristine = scope.form.$pristine;
         if (scope.options.formatters) {
           let value = ctrl.$modelValue;
           ctrl.$formatters.forEach((formatter) => {
@@ -369,6 +370,9 @@ function formlyField($http, $q, $compile, $templateCache, $interpolate, formlyCo
           ctrl.$setViewValue(value);
           ctrl.$render();
           ctrl.$setPristine();
+          if (formWasPristine) {
+            scope.form.$setPristine();
+          }
         }
       }
 

--- a/src/directives/formly-field.test.js
+++ b/src/directives/formly-field.test.js
@@ -1015,7 +1015,7 @@ describe('formly-field', function() {
         expect(ctrl.$viewValue).to.equal('hello! boo!');
       });
 
-      it(`should format a model value right from the start and the form should still be pristine`, () => {
+      it(`should format a model value right from the start and the controller should still be pristine`, () => {
         scope.model = {myKey: 'hello'};
         scope.fields = [getNewField({
           key: 'myKey',
@@ -1028,6 +1028,37 @@ describe('formly-field', function() {
         expect(ctrl.$viewValue).to.equal('!hello!');
         expect(ctrl.$dirty).to.equal(false);
         expect(ctrl.$pristine).to.equal(true);
+      });
+
+      it(`should format a model value on initilization and keep the form state dirty if it was already dirty`, () => {
+        scope.model = {myKey: 'hello'};
+        scope.fields = [getNewField({
+          key: 'myKey',
+          formatters: ['"!" + $viewValue + "!"']
+        })];
+        compileAndDigest();
+        scope.theForm.$setDirty();
+
+        const ctrl = getNgModelCtrl();
+
+        expect(ctrl.$viewValue).to.equal('!hello!');
+        expect(scope.theForm.$dirty).to.equal(true);
+
+      });
+
+      it(`should format a model value on initilization and keep the form state pristine if it was already pristine`, () => {
+        scope.model = {myKey: 'hello'};
+        scope.fields = [getNewField({
+          key: 'myKey',
+          formatters: ['"!" + $viewValue + "!"']
+        })];
+        compileAndDigest();
+
+        const ctrl = getNgModelCtrl();
+
+        expect(ctrl.$viewValue).to.equal('!hello!');
+        expect(scope.theForm.$pristine).to.equal(true);
+
       });
 
       it.skip(`should handle multiple form controllers when formatting a model value right from the start`, () => {


### PR DESCRIPTION
…to ensure that it is functioning as expected. If the form state was dirty it doesn't reset the form to pristine. If the form was pristine. It manually sets it back to pristine after initializing the $viewValue with the formatted view. -🐙