### PR TITLE
Fixes #426: Support for nested model attribute (watcher optimization)

### DIFF
--- a/src/directives/formly-form.test.js
+++ b/src/directives/formly-form.test.js
@@ -406,6 +406,58 @@ describe('formly-form', () => {
     });
   });
 
+  describe('nested model as string', () => {
+    let spy;
+
+    beforeEach(() => {
+      spy = sinon.spy();
+
+      scope.model = {
+        nested: {}
+      };
+
+      scope.fields = [
+        {template: input, key: 'foo'}
+      ];
+    });
+
+    it('starting with "model." should be assigned with only one watcher', () => {
+      scope.fields[0].model = 'model.nested';
+
+      compileAndDigest();
+      $timeout.flush();
+
+      scope.fields[0].expressionProperties = {'data.dummy': spy};
+
+      scope.model.nested.foo = 'value';
+      scope.$digest();
+      $timeout.flush();
+
+      expect(spy).to.have.been.calledOnce;
+    });
+
+    it('starting with "formState." should be assigned with only one watcher', () => {
+      const formWithOptions = '<formly-form model="model" fields="fields" options="options"></formly-form>';
+      scope.options = {
+        formState: {
+          nested: {}
+        }
+      };
+      scope.fields[0].model = 'formState.nested';
+
+      compileAndDigest(formWithOptions);
+      $timeout.flush();
+
+      scope.fields[0].expressionProperties = {'data.dummy': spy};
+
+      scope.options.formState.nested.foo = 'value';
+      scope.$digest();
+      $timeout.flush();
+
+      expect(spy).to.have.been.calledOnce;
+    });
+  });
+
   describe('hideExpression', () => {
     beforeEach(() => {
       scope.model = {};

--- a/src/other/utils.js
+++ b/src/other/utils.js
@@ -1,6 +1,6 @@
 import angular from 'angular-fix';
 
-export default {formlyEval, getFieldId, reverseDeepMerge, findByNodeName, arrayify, extendFunction, extendArray};
+export default {formlyEval, getFieldId, reverseDeepMerge, findByNodeName, arrayify, extendFunction, extendArray, startsWith};
 
 function formlyEval(scope, expression, $modelValue, $viewValue, extraLocals) {
   if (angular.isFunction(expression)) {
@@ -102,3 +102,10 @@ function extendArray(primary, secondary, property) {
   }
 }
 
+function startsWith(str, search) {
+  if (angular.isString(str) && angular.isString(search)) {
+    return str.length >= search.length && str.substring(0, search.length) === search;
+  } else {
+    return false;
+  }
+}

--- a/src/other/utils.test.js
+++ b/src/other/utils.test.js
@@ -2,7 +2,7 @@
 import utils from './utils.js';
 
 // gotta do this because webstorm/jshint doesn't like destructuring imports :-(
-const {extendFunction} = utils;
+const {extendFunction, startsWith} = utils;
 
 
 describe(`utils`, () => {
@@ -20,6 +20,24 @@ describe(`utils`, () => {
       extended('foo');
 
       expect(fn1).to.have.been.calledWith('foo');
+    });
+  });
+
+  describe(`startsWith`, () => {
+    it(`should return true if a string has a given prefix`, () => {
+      expect(startsWith('fooBar', 'foo')).to.be.true;
+    });
+
+    it(`should return false if a string does not have a given prefix`, () => {
+      expect(startsWith('fooBar', 'nah')).to.be.false;
+    });
+
+    it(`should return false if no a string`, () => {
+      expect(startsWith(undefined, 'foo')).to.be.false;
+      expect(startsWith(5, 'foo')).to.be.false;
+      expect(startsWith('foo', undefined)).to.be.false;
+      expect(startsWith('foo', 5)).to.be.false;
+      expect(startsWith(undefined, undefined)).to.be.false;
     });
   });
 


### PR DESCRIPTION
Creating a nested model by specifying a field model as string starting with `model.` does not add a watcher.