### PR TITLE
Formly-Form Directive as Attribute

### DIFF
--- a/src/directives/formly-form.js
+++ b/src/directives/formly-form.js
@@ -5,13 +5,13 @@ export default formlyForm;
 /**
  * @ngdoc directive
  * @name formlyForm
- * @restrict E
+ * @restrict AE
  */
 // @ngInject
 function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpolate) {
   let currentFormId = 1;
   return {
-    restrict: 'E',
+    restrict: 'AE',
     template: formlyFormGetTemplate,
     replace: true,
     transclude: true,

--- a/src/directives/formly-form.test.js
+++ b/src/directives/formly-form.test.js
@@ -21,7 +21,7 @@ describe('formly-form', () => {
     scope.fields = [];
   }));
 
-  it.skip(`should be possible to use it as an attribute directive`, () => {
+  it(`should be possible to use it as an attribute directive`, () => {
     const el = compileAndDigest(`
       <div formly-form model="model" fields="fields" form="theForm"></formly-form>
     `);

--- a/src/directives/formly-form.test.js
+++ b/src/directives/formly-form.test.js
@@ -23,7 +23,7 @@ describe('formly-form', () => {
 
   it(`should be possible to use it as an attribute directive`, () => {
     const el = compileAndDigest(`
-      <div formly-form model="model" fields="fields" form="theForm"></formly-form>
+      <div formly-form model="model" fields="fields" form="theForm"></div>
     `);
     expect(el.length).to.equal(1);
     expect(el.prop('nodeName').toLowerCase()).to.equal('ng-form');


### PR DESCRIPTION
Changed restrictions on formly-form directive to allow usage as an attribute, tests pass.

Also noted ill formed HTML in the test (likely from copy & paste) and corrected in separate commit.