### PR TITLE
feat(formly-form): Use arrays for fieldTransforms

### DIFF
--- a/other/ERRORS_AND_WARNINGS.md
+++ b/other/ERRORS_AND_WARNINGS.md
@@ -127,6 +127,12 @@ of the expression, the scope you're passed wont have all the properties you may 
 See documentation [here](http://docs.angular-formly.com/docs/field-configuration-object#hideexpression-string--function)
 and an example [here](http://angular-formly.com/#/example/field-options/hide-fields)
 
+# FieldTransform as a function deprecated
+
+To allow for plugin like functionality, `fieldTransform` functions on `formlyConfig.extras` and `formly-form.options`
+are now deprecated. Moving forward fieldTransform will accept an array of `fieldTransform` functions. This makes it possible
+to have multiple fieldTransforms. Note, `fieldTransform` functions will be removed in a major release.
+
 # Notes
 
 It is recommended to disable warnings in production using `formlyConfigProvider.disableWarnings = true`. Note: This will

--- a/src/directives/formly-form.test.js
+++ b/src/directives/formly-form.test.js
@@ -6,7 +6,7 @@ import testUtils from '../test.utils.js';
 import angular from 'angular-fix';
 import _ from 'lodash';
 
-const {getNewField, input, basicForm} = testUtils;
+const {getNewField, input, basicForm, shouldWarnWithLog} = testUtils;
 
 describe('formly-form', () => {
   let $compile, formlyConfig, scope, el, $timeout;
@@ -759,6 +759,33 @@ describe('formly-form', () => {
         formlyConfig.extras.fieldTransform = fieldTransform;
       });
 
+      it(`should give a deprecation warning when formlyConfig.extras.fieldTransform is a function rather than an array`, inject(($log) => {
+        shouldWarnWithLog(
+          $log,
+          [
+            'Formly Warning:',
+            'fieldTransform as a function has been deprecated.',
+            /Attempted for formlyConfig.extras/
+          ],
+          compileAndDigest
+        );
+      }));
+
+      it(`should give a deprecation warning when options.fieldTransform function rather than an array`, inject(($log) => {
+        formlyConfig.extras.fieldTransform = undefined;
+        scope.fields = [getNewField()];
+        scope.options.fieldTransform = fields => fields;
+        shouldWarnWithLog(
+          $log,
+          [
+            'Formly Warning:',
+            'fieldTransform as a function has been deprecated.',
+            'Attempted for form'
+          ],
+          compileAndDigest
+        );
+      }));
+
       it(`should throw an error if something is passed in and nothing is returned`, () => {
         scope.fields = [getNewField()];
         scope.options.fieldTransform = function() {
@@ -776,6 +803,20 @@ describe('formly-form', () => {
       it(`should use formlyConfig.extras.fieldTransform when not specified on options`, () => {
         const spy = sinon.spy(formlyConfig.extras, 'fieldTransform');
         doExpectations(spy);
+      });
+
+      it(`should allow you to use an array of transform functions`, () => {
+        scope.fields = [getNewField({
+          customThing: 'foo',
+          otherCustomThing: {
+            whatever: '|-o-|'
+          }})];
+        scope.options.fieldTransform = [fieldTransform];
+        expect(() => compileAndDigest()).to.not.throw();
+
+        const field = scope.fields[0];
+        expect(field).to.have.deep.property('data.customThing');
+        expect(field).to.have.deep.property('data.otherCustomThing');
       });
 
       function doExpectations(spy) {

--- a/src/providers/formlyApiCheck.js
+++ b/src/providers/formlyApiCheck.js
@@ -158,7 +158,6 @@ const fieldOptionsApiShape = {
 
 const formlyFieldOptions = apiCheck.shape(fieldOptionsApiShape).strict;
 
-
 const formOptionsApi = apiCheck.shape({
   formState: apiCheck.object.optional,
   resetModel: apiCheck.func.optional,
@@ -166,7 +165,9 @@ const formOptionsApi = apiCheck.shape({
   removeChromeAutoComplete: apiCheck.bool.optional,
   templateManipulators: templateManipulators.optional,
   wrapper: specifyWrapperType.optional,
-  fieldTransform: apiCheck.func.optional,
+  fieldTransform: apiCheck.oneOfType([
+    apiCheck.func, apiCheck.array
+  ]).optional,
   data: apiCheck.object.optional
 }).strict;
 


### PR DESCRIPTION
Documentation and deprecation warnings for both options and formConfig.extras
Fixes #458