### PR TITLE
fix(formly): Switched from using `Function.bind` to `angular.bind` to support more browsers

### DIFF
--- a/src/directives/formly-custom-validation.js
+++ b/src/directives/formly-custom-validation.js
@@ -17,8 +17,8 @@ function formlyCustomValidation(formlyUtil) {
 
 
       const useNewValidatorsApi = ctrl.hasOwnProperty('$validators') && !attrs.hasOwnProperty('useParsers');
-      angular.forEach(opts.validators, addValidatorToPipeline.bind(null, false));
-      angular.forEach(opts.asyncValidators, addValidatorToPipeline.bind(null, true));
+      angular.forEach(opts.validators, angular.bind(null, addValidatorToPipeline, false));
+      angular.forEach(opts.asyncValidators, angular.bind(null, addValidatorToPipeline, true));
 
       function addValidatorToPipeline(isAsync, validator, name) {
         setupMessage(validator, name);


### PR DESCRIPTION
Fixes issues running formly in PhantomJS.  Other browsers may also have been affected.