### PR TITLE
feat(formly-form): validate field after expressions are run

### DIFF
--- a/src/directives/formly-field.js
+++ b/src/directives/formly-field.js
@@ -59,7 +59,7 @@ function formlyField($http, $q, $compile, $templateCache, $interpolate, formlyCo
     // function definitions
     function runExpressions() {
       // must run on next tick to make sure that the current value is correct.
-      $timeout(function runExpressionsOnNextTick() {
+      return $timeout(function runExpressionsOnNextTick() {
         const field = $scope.options;
         const currentValue = valueGetterSetter();
         angular.forEach(field.expressionProperties, function runExpression(expression, prop) {

--- a/src/directives/formly-field.test.js
+++ b/src/directives/formly-field.test.js
@@ -1690,6 +1690,7 @@ describe('formly-field', function() {
         const $validateSpy = sinon.spy(field.formControl, '$validate');
         scope.model.foo = 'bar';
         scope.$digest();
+        $timeout.flush();
         expect($validateSpy).to.have.been.calledOnce;
       });
     });

--- a/src/directives/formly-form.js
+++ b/src/directives/formly-form.js
@@ -120,13 +120,18 @@ function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpol
     function onModelOrFormStateChange() {
       angular.forEach($scope.fields, function runFieldExpressionProperties(field, index) {
         const model = field.model || $scope.model;
-        field.runExpressions && field.runExpressions();
+        const promise = field.runExpressions && field.runExpressions();
         if (field.hideExpression) { // can't use hide with expressionProperties reliably
           const val = model[field.key];
           field.hide = evalCloseToFormlyExpression(field.hideExpression, val, field, index);
         }
         if (field.extras && field.extras.validateOnModelChange && field.formControl) {
-          field.formControl.$validate();
+          const validate = field.formControl.$validate;
+          if (promise) {
+            promise.then(validate);
+          } else {
+            validate();
+          }
         }
       });
     }


### PR DESCRIPTION
As runExpressions happens on NextTick return a promise and then validate. If there is no promise, just validate straight away