### PR TITLE
fix(formlyConfig.js): added a default for fieldTransform

### DIFF
--- a/src/providers/formlyConfig.js
+++ b/src/providers/formlyConfig.js
@@ -24,6 +24,7 @@ function formlyConfig(formlyUsabilityProvider, formlyErrorAndWarningsUrlPrefix, 
     disableWarnings: false,
     extras: {
       disableNgModelAttrsManipulator: false,
+      fieldTransform: [],
       ngModelAttrsManipulatorPreferUnbound: false,
       removeChromeAutoComplete: false,
       defaultHideDirective: 'ng-if',


### PR DESCRIPTION
This fix removes the need to write formlyConfig.extras.fieldTransform =
formlyConfig.extras.fieldTransform || []; and instead adds an empty array as a default value for
fieldTransform.

closes #517