### PR TITLE
fix(formlyConfig): Removes explicitAsync from formlyConfig.

### DIFF
--- a/src/providers/formlyConfig.js
+++ b/src/providers/formlyConfig.js
@@ -28,8 +28,7 @@ function formlyConfig(formlyUsabilityProvider, formlyErrorAndWarningsUrlPrefix, 
       ngModelAttrsManipulatorPreferUnbound: false,
       removeChromeAutoComplete: false,
       defaultHideDirective: 'ng-if',
-      getFieldId: null,
-      explicitAsync: false
+      getFieldId: null
     },
     templateManipulators: {
       preWrapper: [],


### PR DESCRIPTION
This property is no longer being used. It was deprecated in
SHA:4f9d24752abfab9f5064018b3af3ec61e6bd22c2

closes #516