### PR TITLE
fix(formly-field): Fix formly-field's fc to handle array for issue #510

### DIFF
--- a/src/directives/formly-field.js
+++ b/src/directives/formly-field.js
@@ -340,7 +340,7 @@ function formlyField($http, $q, $compile, $templateCache, $interpolate, formlyCo
         stopWatchingShowError = scope.$watch(function watchShowValidationChange() {
           const customExpression = formlyConfig.extras.errorExistsAndShouldBeVisibleExpression;
           const {options, fc} = scope;
-          if (!fc.$invalid) {
+          if (!arrayify(fc).some(f => f.$invalid)) {
             return false;
           } else if (typeof options.validation.show === 'boolean') {
             return options.validation.show;
@@ -348,7 +348,7 @@ function formlyField($http, $q, $compile, $templateCache, $interpolate, formlyCo
             return formlyUtil.formlyEval(scope, customExpression, fc.$modelValue, fc.$viewValue);
           } else {
             const noTouchedButDirty = (angular.isUndefined(fc.$touched) && fc.$dirty);
-            return (scope.fc.$touched || noTouchedButDirty);
+            return (arrayify(fc).some(f => f.$touched) || noTouchedButDirty);
           }
         }, function onShowValidationChange(show) {
           scope.options.validation.errorExistsAndShouldBeVisible = show;

--- a/src/directives/formly-field.js
+++ b/src/directives/formly-field.js
@@ -346,7 +346,7 @@ function formlyField($http, $q, $compile, $templateCache, $interpolate, formlyCo
           } else if (typeof options.validation.show === 'boolean') {
             return options.validation.show
           } else if (customExpression) {
-            return formControls.some(fc => 
+            return formControls.some(fc =>
               formlyUtil.formlyEval(scope, customExpression, fc.$modelValue, fc.$viewValue))
           } else {
             return formControls.some(fc => {

--- a/src/directives/formly-field.js
+++ b/src/directives/formly-field.js
@@ -339,16 +339,20 @@ function formlyField($http, $q, $compile, $templateCache, $interpolate, formlyCo
       function addShowMessagesWatcher() {
         stopWatchingShowError = scope.$watch(function watchShowValidationChange() {
           const customExpression = formlyConfig.extras.errorExistsAndShouldBeVisibleExpression
-          const {options, fc} = scope
-          if (!arrayify(fc).some(f => f.$invalid)) {
+          const options = scope.options
+          const formControls = arrayify(scope.fc)
+          if (!formControls.some(fc => fc.$invalid)) {
             return false
           } else if (typeof options.validation.show === 'boolean') {
             return options.validation.show
           } else if (customExpression) {
-            return formlyUtil.formlyEval(scope, customExpression, fc.$modelValue, fc.$viewValue)
+            return formControls.some(fc => 
+              formlyUtil.formlyEval(scope, customExpression, fc.$modelValue, fc.$viewValue))
           } else {
-            const noTouchedButDirty = (angular.isUndefined(fc.$touched) && fc.$dirty)
-            return (arrayify(fc).some(f => f.$touched) || noTouchedButDirty)
+            return formControls.some(fc => {
+              const noTouchedButDirty = (angular.isUndefined(fc.$touched) && fc.$dirty)
+              return fc.$touched || noTouchedButDirty
+            })
           }
         }, function onShowValidationChange(show) {
           scope.options.validation.errorExistsAndShouldBeVisible = show

--- a/src/directives/formly-field.test.js
+++ b/src/directives/formly-field.test.js
@@ -1321,7 +1321,7 @@ describe('formly-field', function() {
   });
 
   describe(`options.validation.errorExistsAndShouldBeVisible`, () => {
-    describe.skip(`multiple ng-model elements`, () => {
+    describe(`multiple ng-model elements`, () => {
       beforeEach(() => {
         scope.fields = [
           {


### PR DESCRIPTION
Fixes the addShowMessagesWatcher method in the formly-field directive to handle when fc is an array.