### PR TITLE
fix(formly-form): Fix for setting watches on deep level properties #558

### DIFF
--- a/src/directives/formly-form.js
+++ b/src/directives/formly-form.js
@@ -290,7 +290,7 @@ function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpol
     }
 
     function getWatchExpression(watcher, field, index) {
-      let watchExpression = watcher.expression || `model['${field.key}']`
+      let watchExpression = watcher.expression || 'model[\'' + field.key.toString().split('.').join('\'][\'') + '\']'
       if (angular.isFunction(watchExpression)) {
         // wrap the field's watch expression so we can call it with the field as the first arg
         // and the stop function as the last arg as a helper

--- a/src/directives/formly-form.test.js
+++ b/src/directives/formly-form.test.js
@@ -952,5 +952,28 @@ describe('formly-form', () => {
       expect(listener).to.have.been.called
       expect(expression).to.have.been.called
     })
+
+    it(`should add watches on deep dive fields`, () => {
+      const formWithOptions = '<formly-form model="model" fields="fields" options="options"></formly-form>'
+      scope.model = {}
+      scope.options = {}
+
+      const deepLinkField = getNewField()
+      deepLinkField.key = 'foo.bar'
+      deepLinkField.watcher = {
+        listener: sinon.spy(),
+      }
+
+      scope.fields = [deepLinkField]
+      compileAndDigest(formWithOptions)
+      expect(compileAndDigest).to.not.throw()
+      expect(deepLinkField.watcher.listener).to.have.been.called
+      scope.model.foo = {
+        bar: 'brown',
+      }
+      scope.$digest()
+      expect(compileAndDigest).to.not.throw()
+      expect(deepLinkField.watcher.listener).to.have.been.called
+    })
   })
 })


### PR DESCRIPTION
Updated the getWatchExpression function to set the watch model to use deep level expressions