### PR TITLE
fix(formly-form): added originalModel and formOptions to getFormlyFie…

### DIFF
--- a/src/directives/formly-form.js
+++ b/src/directives/formly-form.js
@@ -369,6 +369,8 @@ function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpol
         options: field,
         index,
         formState: $scope.options.formState,
+        originalModel: '=?',
+        formOptions: '=?',
         formId: $scope.formId,
       }
     }


### PR DESCRIPTION
…ldLikeLocals function

added originalModel and formOptions to getFormlyFieldLikeLocals function

issue #616: #https://github.com/formly-js/angular-formly/issues/616