### PR TITLE
fix relative string models in hideExpression and watchers

### DIFF
--- a/src/directives/formly-form.js
+++ b/src/directives/formly-form.js
@@ -42,7 +42,7 @@ function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpol
                ${getHideDirective()}="!field.hide"
                class="formly-field"
                options="field"
-               model="field.model || model"
+               model="field.model"
                original-model="model"
                fields="fields"
                form="theFormlyForm"
@@ -265,6 +265,8 @@ function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpol
 
         isNewModel = !referencesCurrentlyWatchedModel(expression)
 
+        // temporary assign $scope.model as field.model to evaluate the expression in correct context
+        field.model = $scope.model
         field.model = evalCloseToFormlyExpression(expression, undefined, field, index)
         if (!field.model) {
           throw formlyUsability.getFieldError(
@@ -273,6 +275,8 @@ function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpol
             ' expression must have been initialized ahead of time.',
             field)
         }
+      } else if (!field.model) {
+        field.model = $scope.model
       }
       return isNewModel
     }
@@ -328,6 +332,8 @@ function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpol
           return originalExpression(...args)
         }
         watchExpression.displayName = `Formly Watch Expression for field for ${field.key}`
+      } else if (field.model) {
+        watchExpression = $parse(watchExpression).bind(null, $scope, {model: field.model})
       }
       return watchExpression
     }
@@ -366,6 +372,7 @@ function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpol
     function getFormlyFieldLikeLocals(field, index) {
       // this makes it closer to what a regular formlyExpression would be
       return {
+        model: field.model,
         options: field,
         index,
         formState: $scope.options.formState,

--- a/src/directives/formly-form.test.js
+++ b/src/directives/formly-form.test.js
@@ -597,17 +597,21 @@ describe('formly-form', () => {
     })
 
     it('ensures that hideExpression has all the expressionProperties values', () => {
+      scope.model = {nested: {foo: 'bar', baz: []}}
       scope.options = {formState: {}}
       scope.fields = [{
         template: input,
         key: 'test',
+        model: 'model.nested',
         hideExpression: `
+        model === options.data.model &&
         options === options.data.field &&
         index === 0 &&
         formState === options.data.formOptions.formState &&
         originalModel === options.data.originalModel &&
         formOptions === options.data.formOptions`,
         data: {
+          model: scope.model.nested,
           originalModel: scope.model,
           formOptions: scope.options,
         },
@@ -1196,7 +1200,7 @@ describe('formly-form', () => {
         }
         scope.fields[0].model = model
         scope.fields[0].watcher = [{
-          expression: 'model.nested.foo',
+          expression: 'model.foo',
           runFieldExpressions: true,
         }]
         scope.fields[0].expressionProperties = {
@@ -1363,7 +1367,7 @@ describe('formly-form', () => {
         const field = scope.fields[0]
 
         field.model = 'model.baz'
-        field.hideExpression = 'model.baz.buzz === "bar"'
+        field.hideExpression = 'model.buzz === "bar"'
 
         compileAndDigest()
         $timeout.flush()


### PR DESCRIPTION
<!--

Thanks for your contribution!

Unless this is a really small and insignificant change,
please make sure that we've discussed it first in
the issues.

-->

## What

Previously discussed on my previous PR https://github.com/formly-js/angular-formly/pull/599#issuecomment-172775380

**expect breaking change**

String hideExpression and watchers were evaluated in context of `$scope.model` unlike expressionProperties that were evaluated in the context of the model of a field. That said when you had nested model like `const model = {nested: {foo: 'bar'}};` and your field would have model declared as a string `model: 'model.nested'` your hideExpression and watcher would vary from expressionProperties:
```
hideExpression: 'model.nested.foo === "bar"'
expressionProperties: {
  'some.property': 'model.foo === "bar"'
},
watcher: {
  expression: 'model.nested.foo === "bar"',
  listener: function() {}
}
```

After my tweaks, watchers and hideExpressions that are string-based, are evaluated in the same model context as expressionProperties which is only logical.
```
hideExpression: 'model.foo === "bar"'
expressionProperties: {
  'some.property': 'model.foo === "bar"'
},
watcher: {
  expression: 'model.foo === "bar"',
  listener: function() {}
}
```

## Why

- hideExpression and expressionProperties should be as similar to developer as possible - the mechanism behind them can be different but their api and behavior should be the same thus expression copied from expressionProperty should work with hideExpression and vice versa
- watchExpression was by default `'model.' + key` which didn't work out of a box for nested models because fe. `const model = {nested: {foo: 'bar'}};` with `model: 'model.nested'`, watcherExpression would be `model.foo` because of `watchExpression = 'model[\'' + field.key.toString().split('.').join('\'][\'') + '\']'` and this would not work because it didn't take into account that model was moved to nested child and would expect `model.nested.foo` to work

## How

I have added 2 things:
- in method getFormlyFieldLikeLocals that prepares context for field expressions registered in formly-form controller to look more like these registered from the formly-field controller. getFormlyFieldLikeLocals has one time that field.model is not yet ready - this is on initModel method call that actually resolves field.model and should be run in $scope.model context. Other than that, anything that uses getFormlyFieldLikeLocals should be run with model as field.model.
- watchExpression in formly watcher registration gets run through $parse to add field.model as a model

Checklist:

* [x] Follows the commit message [conventions](https://github.com/stevemao/conventional-changelog-angular/blob/master/convention.md)
* [x] Is [rebased with master](https://egghead.io/lessons/javascript-how-to-rebase-a-git-pull-request-branch?series=how-to-contribute-to-an-open-source-project-on-github)
* [x] Is [only one (maybe two) commits](https://egghead.io/lessons/javascript-how-to-squash-multiple-git-commits)

**I might add a test or two to confirm watchers behavior but wanted to post this PR for first review**

