### PR TITLE
fix(formly-form): validateOnModelChange now copes when field.formControl is an array #523

### DIFF
--- a/src/directives/formly-field.test.js
+++ b/src/directives/formly-field.test.js
@@ -1934,6 +1934,31 @@ describe('formly-field', function() {
         expect($validateSpy).to.have.been.calledOnce
       })
 
+      it(`should cope when field.formControl has been upgraded to an array`, () => {
+        scope.model = {
+          multiNgModel: {
+            start: 'start',
+            stop: 'stop',
+          },
+        }
+        const field = getNewField({
+          key: 'multiNgModel',
+          template: multiNgModelField,
+          extras: {
+            validateOnModelChange: true,
+          },
+        })
+        scope.fields = [field]
+        compileAndDigest()
+        const $validateSpy0 = sinon.spy(field.formControl[0], '$validate')
+        const $validateSpy1 = sinon.spy(field.formControl[1], '$validate')
+        scope.model.foo = 'bar'
+        scope.$digest()
+        $timeout.flush()
+        expect($validateSpy0).to.have.been.calledOnce
+        expect($validateSpy1).to.have.been.calledOnce
+      })
+
       it.skip(`should run field expressions when form is initialised`, () => {
         scope.model = {email: ''}
         scope.fields = [getNewField({

--- a/src/directives/formly-form.js
+++ b/src/directives/formly-form.js
@@ -126,6 +126,15 @@ function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpol
       angular.forEach($scope.fields, runFieldExpressionProperties)
     }
 
+    function validateFormControl(formControl, promise) {
+      const validate = formControl.$validate
+      if (promise) {
+        promise.then(validate)
+      } else {
+        validate()
+      }
+    }
+
     function runFieldExpressionProperties(field, index) {
       const model = field.model || $scope.model
       const promise = field.runExpressions && field.runExpressions()
@@ -134,11 +143,12 @@ function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpol
         field.hide = evalCloseToFormlyExpression(field.hideExpression, val, field, index)
       }
       if (field.extras && field.extras.validateOnModelChange && field.formControl) {
-        const validate = field.formControl.$validate
-        if (promise) {
-          promise.then(validate)
+        if (angular.isArray(field.formControl)) {
+          angular.forEach(field.formControl, function(formControl) {
+            validateFormControl(formControl, promise)
+          })
         } else {
-          validate()
+          validateFormControl(field.formControl, promise)
         }
       }
     }


### PR DESCRIPTION
<!--

Thanks for your contribution!

Unless this is a really small and insignificant change,
please make sure that we've discussed it first in
the issues.

-->

## What

Fix for issue #523

## Why

Bug fix

## How

<!-- explain how you did it -->

If field.formControl is an array, then call $validate method of each element

Checklist:

* [x] Follows the commit message [conventions](https://github.com/stevemao/conventional-changelog-angular/blob/master/convention.md)
* [x] Is [rebased with master](https://egghead.io/lessons/javascript-how-to-rebase-a-git-pull-request-branch?series=how-to-contribute-to-an-open-source-project-on-github)
* [x] Is [only one (maybe two) commits](https://egghead.io/lessons/javascript-how-to-squash-multiple-git-commits)

