### PR TITLE
fix(models): update field model reference for fields with nested string models

### DIFF
--- a/src/directives/formly-form.test.js
+++ b/src/directives/formly-form.test.js
@@ -495,6 +495,24 @@ describe('formly-form', () => {
       testFormStateAccessor('formState["nested"]')
     })
 
+    it('should be updated when the reference to the outer model changes', () => {
+      scope.model.nested.foo = 'bar'
+      scope.fields[0].model = 'model.nested'
+
+      compileAndDigest()
+      $timeout.flush()
+
+      scope.model = {
+        nested: {
+          foo: 'baz',
+        },
+      }
+
+      scope.$digest()
+
+      expect(scope.fields[0].model.foo).to.equal('baz')
+    })
+
     function testModelAccessor(accessor) {
       scope.fields[0].model = accessor
 


### PR DESCRIPTION
<!--

Thanks for your contribution!

Unless this is a really small and insignificant change,
please make sure that we've discussed it first in
the issues.

-->

## What

String field models were resolved just once on init and when the outer model ($scope.model) is totally overridden, the field's model still references the old model. 

## How

I have added a shallow reference watcher to every field that has string model. It checks if the reference changed and updates `field.model` accordingly.
I had to add 5th parameter to `evalCloseToFormlyExpression` because I didn't want to override the `field` object on each watcher. This might seem a bit dirty :+1: 
Test case for the fix added.

Checklist:

* [x] Follows the commit message [conventions](https://github.com/stevemao/conventional-changelog-angular/blob/master/convention.md)
* [x] Is [rebased with master](https://egghead.io/lessons/javascript-how-to-rebase-a-git-pull-request-branch?series=how-to-contribute-to-an-open-source-project-on-github)
* [x] Is [only one (maybe two) commits](https://egghead.io/lessons/javascript-how-to-squash-multiple-git-commits)