### PR TITLE
fix(model): keep track of correct model reference

### DIFF
--- a/src/directives/formly-form.js
+++ b/src/directives/formly-form.js
@@ -42,7 +42,7 @@ function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpol
                ${getHideDirective()}="!field.hide"
                class="formly-field"
                options="field"
-               model="field.model"
+               model="field.model || model"
                original-model="model"
                fields="fields"
                form="theFormlyForm"
@@ -140,7 +140,7 @@ function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpol
       const promise = field.runExpressions && field.runExpressions()
       if (field.hideExpression) { // can't use hide with expressionProperties reliably
         const val = model[field.key]
-        field.hide = evalCloseToFormlyExpression(field.hideExpression, val, field, index)
+        field.hide = evalCloseToFormlyExpression(field.hideExpression, val, field, index, {model})
       }
       if (field.extras && field.extras.validateOnModelChange && field.formControl) {
         if (angular.isArray(field.formControl)) {
@@ -261,7 +261,7 @@ function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpol
         const model = field.model || $scope.model
         $scope.$watch(function hideExpressionWatcher() {
           const val = model[field.key]
-          return evalCloseToFormlyExpression(field.hideExpression, val, field, index)
+          return evalCloseToFormlyExpression(field.hideExpression, val, field, index, {model})
         }, (hide) => field.hide = hide, true)
       }
     }
@@ -277,9 +277,8 @@ function formlyForm(formlyUsability, formlyWarn, $parse, formlyConfig, $interpol
         field.model = resolveStringModel(expression)
 
         $scope.$watch(() => resolveStringModel(expression), (model) => field.model = model)
-      } else if (!field.model) {
-        field.model = $scope.model
       }
+
       return isNewModel
 
       function resolveStringModel(expression) {

--- a/src/directives/formly-form.test.js
+++ b/src/directives/formly-form.test.js
@@ -445,6 +445,7 @@ describe('formly-form', () => {
         {template: input, key: 'foo', model: scope.fieldModel1},
         {template: input, key: 'bar', model: scope.fieldModel1},
         {template: input, key: 'zoo', model: scope.fieldModel1},
+        {template: input, key: 'test'},
       ]
     })
 
@@ -461,6 +462,21 @@ describe('formly-form', () => {
 
       expect(spy1).to.have.been.calledOnce
       expect(spy2).to.have.been.calledOnce
+    })
+
+    it('should be updated when the reference to the model changes', () => {
+      scope.model = {test: 'bar'}
+      scope.fields[3].expressionProperties = {'data.test': 'model.test'}
+
+      compileAndDigest()
+      $timeout.flush()
+
+      scope.model = {test: 'baz'}
+
+      scope.$digest()
+      $timeout.flush()
+
+      expect(scope.fields[3].data.test).to.equal('baz')
     })
   })
 
@@ -498,6 +514,7 @@ describe('formly-form', () => {
     it('should be updated when the reference to the outer model changes', () => {
       scope.model.nested.foo = 'bar'
       scope.fields[0].model = 'model.nested'
+      scope.fields[0].expressionProperties = {'data.foo': 'model.foo'}
 
       compileAndDigest()
       $timeout.flush()
@@ -509,8 +526,9 @@ describe('formly-form', () => {
       }
 
       scope.$digest()
+      $timeout.flush()
 
-      expect(scope.fields[0].model.foo).to.equal('baz')
+      expect(scope.fields[0].data.foo).to.equal('baz')
     })
 
     function testModelAccessor(accessor) {


### PR DESCRIPTION
<!--

Thanks for your contribution!

Unless this is a really small and insignificant change,
please make sure that we've discussed it first in
the issues.

-->

## What

Fix for issue #656

## Why

I did not take into account such basic scenario - no test case was failing and it all seemed to work on my app

## How

`field` object does not contain `model` property that is the model itself for the basic field usage where the model is `$scope.model`. I assumed we could then assign this `$scope.model` as a property to `field` object and operate only on this property. This would make it consistent with the scenarios when `field.model` was passed as a string and resolved to an object (with a watcher) or assigned as an custom object.
This was a mistake because when `scope.model` reference changed, `field.model` referenced old model object. To make it work I would have to put a watcher on `scope.model` and update `field.model` accordingly but this would add a lot of unnecessary watchers so I've reverted to the original solution where we use construction `field.model || scope.model` which works fine now.

One test case added, one test case fixed.

For issue #656

Checklist:

* [x] Follows the commit message [conventions](https://github.com/stevemao/conventional-changelog-angular/blob/master/convention.md)
* [x] Is [rebased with master](https://egghead.io/lessons/javascript-how-to-rebase-a-git-pull-request-branch?series=how-to-contribute-to-an-open-source-project-on-github)
* [x] Is [only one (maybe two) commits](https://egghead.io/lessons/javascript-how-to-squash-multiple-git-commits)

closes #656

