### PR TITLE
fix(formly-field): fixed check in parseSet/parseGet to permit 0 keys

### DIFF
--- a/src/directives/formly-field.js
+++ b/src/directives/formly-field.js
@@ -104,7 +104,7 @@ function formlyField($http, $q, $compile, $templateCache, $interpolate, formlyCo
 
     function parseSet(key, model, newVal) {
       // If either of these are null/undefined then just return undefined
-      if (!key || !model) {
+      if ((!key && key !== 0) || !model) {
         return
       }
       // If we are working with a number then $parse wont work, default back to the old way for now
@@ -121,7 +121,7 @@ function formlyField($http, $q, $compile, $templateCache, $interpolate, formlyCo
 
     function parseGet(key, model) {
       // If either of these are null/undefined then just return undefined
-      if (!key || !model) {
+      if ((!key && key !== 0) || !model) {
         return undefined
       }
 

--- a/src/directives/formly-field.test.js
+++ b/src/directives/formly-field.test.js
@@ -500,6 +500,13 @@ describe('formly-field', function() {
       expect(scope.fields[0].initialValue).to.eq(defaultValue)
     })
 
+    it(`should be set if the key is 0`, () => {
+      scope.fields[0].key = 0
+      compileAndDigest()
+
+      expect(scope.fields[0].initialValue).to.eq(defaultValue)
+    })
+
     describe(`nested keys`, () => {
       const nestedObject = 'foo.bar'
       const nestedArray = 'baz[0]'
@@ -535,6 +542,19 @@ describe('formly-field', function() {
 
     it('should get and set values when key is all numeric', () => {
       const key = '1333'
+      const defaultValue = 'bar'
+
+      scope.fields = [
+        {template: input, key, defaultValue},
+      ]
+      scope.model = {}
+
+      compileAndDigest()
+      expect(scope.model[key]).to.eq(defaultValue)
+    })
+
+    it('should get and set values when key is 0', () => {
+      const key = 0
       const defaultValue = 'bar'
 
       scope.fields = [


### PR DESCRIPTION
## What

Change check in `parseSet()/parseGet()` to permit a numeric 0 key.

## Why

Looking at `parseSet()/parseGet()`, the intended behavior seems to be that numeric keys mean array indexes. However, `parseSet()/parseGet()` will return prematurely if a `0` key is used.

## How

Modified the check to permit `0` (and keep existing behavior for all other falsy values).

For issue #658 
