### PR TITLE
feat(formlyConfigProvider): Expose field types map from formlyConfigProvider

### DIFF
--- a/src/providers/formlyConfig.js
+++ b/src/providers/formlyConfig.js
@@ -15,6 +15,7 @@ function formlyConfig(formlyUsabilityProvider, formlyErrorAndWarningsUrlPrefix, 
   angular.extend(this, {
     setType,
     getType,
+    getTypes,
     getTypeHeritage,
     setWrapper,
     getWrapper,
@@ -159,6 +160,10 @@ function formlyConfig(formlyUsabilityProvider, formlyErrorAndWarningsUrlPrefix, 
     } else {
       return type
     }
+  }
+
+  function getTypes() {
+    return typeMap
   }
 
   function getTypeHeritage(parent) {

--- a/src/providers/formlyConfig.test.js
+++ b/src/providers/formlyConfig.test.js
@@ -185,8 +185,8 @@ describe('formlyConfig', () => {
   })
 
 
-  describe('setType/getType', () => {
-    let getterFn, setterFn
+  describe('setType/getType/getTypes', () => {
+    let getterFn, setterFn, getTypesFn
     const name = 'input'
     const template = '<input type="{{options.inputType}}" />'
     const templateUrl = '/input.html'
@@ -195,6 +195,7 @@ describe('formlyConfig', () => {
     beforeEach(inject(function(formlyConfig) {
       getterFn = formlyConfig.getType
       setterFn = formlyConfig.setType
+      getTypesFn = formlyConfig.getTypes
     }))
 
     describe('＼(＾O＾)／ path', () => {
@@ -215,6 +216,14 @@ describe('formlyConfig', () => {
         ])
         expect(getterFn(name).template).to.equal(template)
         expect(getterFn('type2').templateUrl).to.equal(templateUrl)
+      })
+
+      it('should expose the mapping from type name to config', () => {
+        setterFn([
+          {name, template},
+          {name: 'type2', templateUrl},
+        ])
+        expect(getTypesFn()).to.eql({[name]: getterFn(name), type2: getterFn('type2')})
       })
 
       it('should allow you to set a wrapper as a string', () => {


### PR DESCRIPTION
## What

Adding a `getTypes()` method to `formlyConfigProvider` that returns the map of type to config.

## Why

For a plugin I am writing that renders an inspector showing the current configuration for formly, I
need access to the types that have been registered with formly.

## How

This change exposes the map of type name to type configuration object via a new method on `formlyConfigProvider` called `getTypes()`.

For issue #663

Checklist:

* [x] Follows the commit message [conventions](https://github.com/stevemao/conventional-changelog-angular/blob/master/convention.md)
* [x] Is [rebased with master](https://egghead.io/lessons/javascript-how-to-rebase-a-git-pull-request-branch?series=how-to-contribute-to-an-open-source-project-on-github)
* [x] Is [only one (maybe two) commits](https://egghead.io/lessons/javascript-how-to-squash-multiple-git-commits)