### PR TITLE
fix(formlyConfig): fix defaultOptions override behavior

### DIFF
--- a/src/providers/formlyConfig.js
+++ b/src/providers/formlyConfig.js
@@ -124,7 +124,7 @@ function formlyConfig(formlyUsabilityProvider, formlyErrorAndWarningsUrlPrefix, 
     if (!angular.isDefined(extendsDO)) {
       return
     }
-    const optionsDO = options.defaultOptions
+    const optionsDO = options.defaultOptions || {}
     const optionsDOIsFn = angular.isFunction(optionsDO)
     const extendsDOIsFn = angular.isFunction(extendsDO)
     if (extendsDOIsFn) {
@@ -136,8 +136,8 @@ function formlyConfig(formlyUsabilityProvider, formlyErrorAndWarningsUrlPrefix, 
         if (optionsDOIsFn) {
           extenderOptionsDefaultOptions = extenderOptionsDefaultOptions(mergedDefaultOptions, scope)
         }
-        utils.reverseDeepMerge(extendsDefaultOptions, extenderOptionsDefaultOptions)
-        return extendsDefaultOptions
+        utils.reverseDeepMerge(extenderOptionsDefaultOptions, extendsDefaultOptions)
+        return extenderOptionsDefaultOptions
       }
     } else if (optionsDOIsFn) {
       options.defaultOptions = function defaultOptions(opts, scope) {

--- a/src/providers/formlyConfig.test.js
+++ b/src/providers/formlyConfig.test.js
@@ -287,6 +287,68 @@ describe('formlyConfig', () => {
           })
 
         })
+        
+        describe(`abstractType function case`, () => {
+          beforeEach(() => {
+            setterFn([
+              {
+                name,
+                template,
+                defaultOptions: function(options) {
+                  return {
+                    templateOptions: {
+                      required: true,
+                      min: 3,
+                    },
+                  }
+                },
+              },
+              {
+                name: 'type2',
+                extends: name,
+                defaultOptions: function(options) {
+                  return {
+                    templateOptions: {
+                      required: false,
+                      max: 4,
+                    },
+                  }
+                },
+              },
+              {
+                name: 'type3',
+                extends: name,
+                defaultOptions: {
+                  templateOptions: {
+                    required: false,
+                    max: 4,
+                  },
+                },
+              },
+            ])
+          })
+
+          it(`should merge options when extending defaultOptions is a function`, () => {
+            expect(getterFn('type2').defaultOptions({})).to.eql({
+              templateOptions: {
+                required: false,
+                min: 3,
+                max: 4,
+              },
+            })
+          })
+          
+          it(`should merge options when extending defaultOptions is an object`, () => {
+            expect(getterFn('type3').defaultOptions({})).to.eql({
+              templateOptions: {
+                required: false,
+                min: 3,
+                max: 4,
+              },
+            })
+          })
+
+        })
 
         describe(`template/templateUrl Cases`, () => {
           it('should use templateUrl if type defines it and its parent has template defined', function() {


### PR DESCRIPTION
<!--

Thanks for your contribution!

Unless this is a really small and insignificant change,
please make sure that we've discussed it first in
the issues.

-->

## What
When the defaultOptions of a type are defined as a function and a different type extends it, the defaultOptions of the extending type are not correct.
<!-- explain what is being done here -->

## Why
It is a bug.
<!-- explain why it's necessary -->

## How
The ordering in the reverseDeepMerge() function was reversed and the incorrect object was being returned.  This change flips the parameters and returns the correct object.
<!-- explain how you did it -->

For issue #635 

Checklist:

* [x ] Follows the commit message [conventions](https://github.com/stevemao/conventional-changelog-angular/blob/master/convention.md)
* [x ] Is [rebased with master](https://egghead.io/lessons/javascript-how-to-rebase-a-git-pull-request-branch?series=how-to-contribute-to-an-open-source-project-on-github)
* [x ] Is [only one (maybe two) commits](https://egghead.io/lessons/javascript-how-to-squash-multiple-git-commits)


Fix the override behavior when the extended type's defaultOptions field is defined as a function.

Closes #635