### PR TITLE
feat(formly-form): formlyField.runExpressions resolve after fields ha…

### DIFF
--- a/src/directives/formly-form.test.js
+++ b/src/directives/formly-form.test.js
@@ -1314,4 +1314,47 @@ describe('formly-form', () => {
       })
     })
   })
+  describe('extras', () => {
+    describe('validateOnModelChange', () => {
+      it('should run validators after expressions are set', () => {
+        let inputs, invalidInputs, el
+
+        scope.model = {
+          foo: null,
+          bar: 123,
+        }
+
+        scope.fields = [
+          {template: input, key: 'foo', extras: {validateOnModelChange: true}},
+          {template: input, key: 'bar', templateOptions: {type: 'number'}},
+        ]
+        // First Field isn't valid when second field is 1
+        scope.fields[0].expressionProperties = {
+          'templateOptions.isValid': 'model.bar !== 1',
+        }
+        // validator to use isValid attribute
+        scope.fields[0].validators = {isValid: {expression: (viewValue, modelValue, fieldScope) => {
+          return fieldScope.to.isValid
+        }}}
+
+        el = compileAndDigest()
+
+        // Input state before
+        inputs = el[0].querySelectorAll('input')
+        invalidInputs = el[0].querySelectorAll('input.ng-invalid')
+        expect(inputs.length).to.equal(2)
+        expect(invalidInputs.length).to.equal(0)
+
+        // Enter '1' into second field
+        angular.element(inputs[1]).val(1).triggerHandler('change')
+        $timeout.flush()
+
+        // Input state after
+        inputs = el[0].querySelectorAll('input')
+        invalidInputs = el[0].querySelectorAll('input.ng-invalid')
+        expect(inputs.length).to.equal(2)
+        expect(invalidInputs.length).to.equal(1)
+      })
+    })
+  })
 })


### PR DESCRIPTION
<!--

Thanks for your contribution!

Unless this is a really small and insignificant change,
please make sure that we've discussed it first in
the issues.

-->

## What

resolve promise from formlyField.runExpressions after fields have been set instead of $timeout promise

## Why

$timeout promise will resolve before the async field setters have finished

## How

using $q.all to resolve the promise after all the field setter promises are finished

For issue # 523

Checklist:

* [x] Follows the commit message [conventions](https://github.com/stevemao/conventional-changelog-angular/blob/master/convention.md)
* [x] Is [rebased with master](https://egghead.io/lessons/javascript-how-to-rebase-a-git-pull-request-branch?series=how-to-contribute-to-an-open-source-project-on-github)
* [x] Is [only one (maybe two) commits](https://egghead.io/lessons/javascript-how-to-squash-multiple-git-commits)