### PR TITLE
fix(FormlyFormController): Fix validateOnModelChange not firing with promise change #523

### DIFF
--- a/src/directives/formly-form.controller.js
+++ b/src/directives/formly-form.controller.js
@@ -30,7 +30,7 @@ export default function FormlyFormController(
   function validateFormControl(formControl, promise) {
     const validate = formControl.$validate
     if (promise) {
-      promise.then(validate)
+      promise.then(() => validate.apply(formControl))
     } else {
       validate()
     }


### PR DESCRIPTION
<!--

Thanks for your contribution!

Unless this is a really small and insignificant change,
please make sure that we've discussed it first in
the issues.

-->

## What

In FormlyFormController in function validateFormControl variable validate was invoked with "undefined" this if the function was called with a promise.

## Why

It's a bug.

## How

Used a closure and apply() to ensure validate() will be called with formController as this.

For issue #523 

Checklist:

* [X] Follows the commit message [conventions](https://github.com/stevemao/conventional-changelog-angular/blob/master/convention.md)
* [X] Is [rebased with master](https://egghead.io/lessons/javascript-how-to-rebase-a-git-pull-request-branch?series=how-to-contribute-to-an-open-source-project-on-github)
* [X] Is [only one (maybe two) commits](https://egghead.io/lessons/javascript-how-to-squash-multiple-git-commits)

Fixes validate being called with undefined this variable scope.

Closes #523 