### PR TITLE
docs(README): add link to ngx-formly

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ application's forms.
 
 From there, it's just JavaScript. Allowing for DRY, maintainable, reusable forms.
 
+> **IMPORTANT:** This is the formly project for AngularJS (v1.x). If you're looking for an **Angular (v2+) alternative**, take a look at the [ngx-formly](https://github.com/formly-js/ngx-formly) project.
+
+
 ## [Learning](http://learn.angular-formly.com)
 
 ### Egghead.io Lessons


### PR DESCRIPTION
## What

This is just an update to the current README.

## Why

A lot of people may come by here in search of an Angular (2+) version of it. I think it's worth pointing to ngx-formly which is a very powerful and viable alternative :smiley:

Checklist:

* [x] Follows the commit message [conventions](https://github.com/stevemao/conventional-changelog-angular/blob/master/convention.md)
* [x] Is [rebased with master](https://egghead.io/lessons/javascript-how-to-rebase-a-git-pull-request-branch?series=how-to-contribute-to-an-open-source-project-on-github)
* [x] Is [only one (maybe two) commits](https://egghead.io/lessons/javascript-how-to-squash-multiple-git-commits)

//cc @aitboudad 

